### PR TITLE
Update angular utility

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -27,7 +27,7 @@
     "moment": "~2.10.3"
   },
   "devDependencies": {
-    "angular-mocks": "~1.3.15"
+    "angular-mocks": "~1.4.5"
   },
   "license": "MIT",
   "moduleType": [

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-angular-utilities",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Typescript utility classes published as angular services",
   "authors": [
     "Renovo Development Team"

--- a/source/services/test/angularFixture.ts
+++ b/source/services/test/angularFixture.ts
@@ -65,10 +65,10 @@ module rl.utilities.services.test {
 				controllerBindings = bindings;
 				scope = $rootScope.$new();
 			} else {
-				bindings = _.extend($rootScope.$new(), bindings);
-				locals.$scope = bindings;
-				scope = bindings;
+				scope = _.extend($rootScope.$new(), bindings);
 			}
+
+			locals.$scope = scope;
 
 			return {
 				scope: scope,

--- a/source/services/test/angularFixture.ts
+++ b/source/services/test/angularFixture.ts
@@ -67,6 +67,7 @@ module rl.utilities.services.test {
 			} else {
 				bindings = _.extend($rootScope.$new(), bindings);
 				locals.$scope = bindings;
+				scope = bindings;
 			}
 
 			return {

--- a/source/services/test/angularFixture.ts
+++ b/source/services/test/angularFixture.ts
@@ -49,22 +49,29 @@ module rl.utilities.services.test {
 			});
 		}
 
-		controller<TControllerType>(controllerName: string, scope?: any, locals?: any): IControllerResult<TControllerType> {
+		controller<TControllerType>(controllerName: string, bindings?: any, locals?: any, bindToController: boolean = false)
+			: IControllerResult<TControllerType> {
 			var services: any = this.inject('$rootScope', '$controller');
-			var $rootScope: angular.IScope = services.$rootScope;
-			var $controller: any = services.$controller;
-
-			scope = _.extend($rootScope.$new(), scope);
+			var $rootScope: ng.IScope = services.$rootScope;
+			var $controller: ng.IControllerService = services.$controller;
+			var controllerBindings: any;
+			var scope: ng.IScope;
 
 			if (locals == null) {
 				locals = {};
 			}
 
-			locals.$scope = scope;
+			if (bindToController) {
+				controllerBindings = bindings;
+				scope = $rootScope.$new();
+			} else {
+				bindings = _.extend($rootScope.$new(), bindings);
+				locals.$scope = bindings;
+			}
 
 			return {
 				scope: scope,
-				controller: <TControllerType>$controller(controllerName, locals),
+				controller: <TControllerType>$controller(controllerName, locals, controllerBindings),
 			};
 		}
 

--- a/source/services/test/angularFixture.ts
+++ b/source/services/test/angularFixture.ts
@@ -5,12 +5,12 @@
 module rl.utilities.services.test {
 	export interface IControllerResult<TControllerType> {
 		controller: TControllerType;
-		scope: angular.IScope;
+		scope: ng.IScope;
 	}
 
 	export interface IDirectiveResult {
-		directive: angular.IDirective;
-		scope: angular.IScope;
+		directive: ng.IDirective;
+		scope: ng.IScope;
 	}
 
 	export interface IAngularFixture {
@@ -42,7 +42,7 @@ module rl.utilities.services.test {
 		}
 
 		mock(mocks: any): void {
-			angular.mock.module(($provide: angular.auto.IProvideService) => {
+			angular.mock.module(($provide: ng.auto.IProvideService) => {
 				_.each(mocks, (value: any, key: number) => {
 					$provide.value(key.toString(), value);
 				});
@@ -70,7 +70,7 @@ module rl.utilities.services.test {
 
 		directive(dom: string): IDirectiveResult {
 			var services: any = this.inject('$rootScope', '$compile');
-			var $rootScope: angular.IScope = services.$rootScope;
+			var $rootScope: ng.IScope = services.$rootScope;
 			var $compile: any = services.$compile;
 
 			angular.mock.module('renovoTemplates');

--- a/typings/angularMocks.d.ts
+++ b/typings/angularMocks.d.ts
@@ -49,4 +49,9 @@ declare module angular {
 		flush(delay: number): void;
 		verifyNoPendingTasks(): void;
 	}
+
+	interface IControllerService {
+		(controllerConstructor: Function, locals?: any, bindings?: any): any;
+        (controllerName: string, locals?: any, bindings?: any): any;
+	}
 }


### PR DESCRIPTION
Updated angular utility to support bindToController. The consumer can pass a fourth parameter to controller() which specifies if the bindings (second parameter) should go to the controller or to the scope.
