### PR TITLE
Bind to controller refinements

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-angular-utilities",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "Typescript utility classes published as angular services",
   "authors": [
     "Renovo Development Team"

--- a/source/services/test/angularFixture.ts
+++ b/source/services/test/angularFixture.ts
@@ -1,6 +1,6 @@
-﻿// uses typings/angularjs
-// uses typings/lodash
-// uses typings/angularMocks
+﻿// /// <reference path='../../../typings/angularjs/angular.d.ts' />
+// /// <reference path='../../../typings/lodash/lodash.d.ts' />
+// /// <reference path='../../../typings/angularMocks.d.ts' />
 
 module rl.utilities.services.test {
 	export interface IControllerResult<TControllerType> {
@@ -16,7 +16,7 @@ module rl.utilities.services.test {
 	export interface IAngularFixture {
 		inject: (...serviceNames: string[]) => any;
 		mock: (mocks: any) => void;
-		controller<TControllerType>(controllerName: string, bindings?: any, locals?: any, bindToController?: boolean)
+		controllerWithBindings<TControllerType>(controllerName: string, bindings?: any, locals?: any, scope?: any)
 			: IControllerResult<TControllerType>;
 		directive: (dom: string) => IDirectiveResult;
 	}
@@ -50,30 +50,23 @@ module rl.utilities.services.test {
 			});
 		}
 
-		controller<TControllerType>(controllerName: string, bindings?: any, locals?: any, bindToController: boolean = false)
+		controllerWithBindings<TControllerType>(controllerName: string, bindings?: any, locals?: any, scope?: any)
 			: IControllerResult<TControllerType> {
 			var services: any = this.inject('$rootScope', '$controller');
-			var $rootScope: ng.IScope = services.$rootScope;
+			var $rootScope: ng.IRootScopeService = services.$rootScope;
 			var $controller: ng.IControllerService = services.$controller;
-			var controllerBindings: any;
-			var scope: ng.IScope;
+
+			scope = _.extend($rootScope.$new(), scope);
 
 			if (locals == null) {
 				locals = {};
-			}
-
-			if (bindToController) {
-				controllerBindings = bindings;
-				scope = $rootScope.$new();
-			} else {
-				scope = _.extend($rootScope.$new(), bindings);
 			}
 
 			locals.$scope = scope;
 
 			return {
 				scope: scope,
-				controller: <TControllerType>$controller(controllerName, locals, controllerBindings),
+				controller: <TControllerType>$controller(controllerName, locals, bindings),
 			};
 		}
 


### PR DESCRIPTION
Renamed angularFixture.controller to controllerWithBindings and made some changes to make it work more nicely with bindToController syntax. This is a breaking change for all usages of angularFixture.controller.
