### PR TITLE
Get error count and aggregate validators

### DIFF
--- a/source/services/validation/aggregateValidator.ts
+++ b/source/services/validation/aggregateValidator.ts
@@ -1,0 +1,60 @@
+'use strict';
+
+import * as _ from 'lodash';
+
+import { IValidationService, IValidationHandler } from './validation.service';
+import { IValidator, Validator, IErrorHandler, IUnregisterFunction } from './validator';
+
+interface IRegisteredValidator extends IValidator {
+	key: number;
+}
+
+export interface IAggregateValidator {
+	validate(): boolean;
+	getErrorCount(): number;
+	buildChildValidator(): IValidator;
+	unregisterChild(validator: IValidator): void;
+}
+
+export class AggregateValidator implements IAggregateValidator {
+	private childValidators: { [index: number]: IValidator } = {};
+	private nextKey: number = 0;
+
+	constructor(private showError: IErrorHandler) {}
+
+	validate(): boolean {
+		let isValid: boolean = true;
+
+		_.each(this.childValidators, (handler: IValidator): boolean => {
+			if (!handler.validate()) {
+				isValid = false;
+				return false;
+			}
+		});
+
+		return isValid;
+	}
+
+	getErrorCount(): number {
+		return _.reduce(<any>this.childValidators, (count: number, handler: IValidator): number => {
+			return count += handler.getErrorCount();
+		}, 0);
+	}
+
+	buildChildValidator(): IValidator {
+		let validator: IValidator = new Validator((error: string): void => {
+			this.showError(error);
+		});
+
+		var currentKey: number = this.nextKey;
+		this.nextKey++;
+		this.childValidators[currentKey] = validator;
+		(<IRegisteredValidator>validator).key = currentKey;
+
+		return validator;
+	}
+
+	unregisterChild(validator: IValidator): void {
+		delete this.childValidators[(<IRegisteredValidator>validator).key];
+	}
+}

--- a/source/services/validation/compositeValidator.ts
+++ b/source/services/validation/compositeValidator.ts
@@ -9,14 +9,14 @@ interface IRegisteredValidator extends IValidator {
 	key: number;
 }
 
-export interface IAggregateValidator {
+export interface ICompositeValidator {
 	validate(): boolean;
 	getErrorCount(): number;
 	buildChildValidator(): IValidator;
 	unregisterChild(validator: IValidator): void;
 }
 
-export class AggregateValidator implements IAggregateValidator {
+export class CompositeValidator implements ICompositeValidator {
 	private childValidators: { [index: number]: IValidator } = {};
 	private nextKey: number = 0;
 

--- a/source/services/validation/validation.service.tests.ts
+++ b/source/services/validation/validation.service.tests.ts
@@ -237,4 +237,37 @@ describe('validation', () => {
 			sinon.assert.calledWith(notification.warning, 'error');
 		});
 	});
+
+	describe('getErrorCount', (): void => {
+		it('should get the count of failing validators', (): void => {
+			let validHandler: IMockValidationHandler = {
+				validate: sinon.spy((): boolean => { return true; }),
+			};
+			let firstFailingHandler: IMockValidationHandler = {
+				validate: sinon.spy((): boolean => { return false; }),
+			};
+			let inactiveFailingHandler: IMockValidationHandler = {
+				validate: sinon.spy((): boolean => { return false; }),
+				isActive: false,
+			};
+			let secondFailingHandler: IMockValidationHandler = {
+				validate: sinon.spy((): boolean => { return false; }),
+			};
+
+			validator.registerValidationHandler(<any>validHandler);
+			validator.registerValidationHandler(<any>firstFailingHandler);
+			validator.registerValidationHandler(<any>inactiveFailingHandler);
+			validator.registerValidationHandler(<any>secondFailingHandler);
+
+			let errorCount: number = validator.getErrorCount();
+
+			sinon.assert.calledOnce(firstFailingHandler.validate);
+			sinon.assert.calledOnce(firstFailingHandler.validate);
+			sinon.assert.calledOnce(secondFailingHandler.validate);
+
+			sinon.assert.notCalled(inactiveFailingHandler.validate);
+
+			expect(errorCount).to.equal(2);
+		});
+	});
 });

--- a/source/services/validation/validation.service.tests.ts
+++ b/source/services/validation/validation.service.tests.ts
@@ -5,7 +5,7 @@
 
 'use strict';
 
-import { IUnregisterFunction, IValidationServiceFactory, IValidationService, moduleName, factoryName } from './validation.service';
+import { IUnregisterFunction, IValidationService, moduleName, serviceName, IValidator } from './validation.service';
 
 import { angularFixture } from '../test/angularFixture';
 
@@ -24,11 +24,15 @@ interface IMockNotification {
 }
 
 describe('validation', () => {
-	var validation: IValidationService;
-	var notification: IMockNotification;
+	let validationService: IValidationService;
+	let validator: IValidator;
+	let notification: IMockNotification;
+	let showErrorSpy: Sinon.SinonSpy;
 
 	beforeEach(() => {
 		angular.mock.module(moduleName);
+
+		showErrorSpy = sinon.spy();
 
 		notification = {
 			error: sinon.spy(),
@@ -39,65 +43,50 @@ describe('validation', () => {
 			notification: notification,
 		});
 
-		var services: any = angularFixture.inject(factoryName);
-		var validationFactory: IValidationServiceFactory = services[factoryName];
-		validation = validationFactory.getInstance();
+		let services: any = angularFixture.inject(serviceName);
+		validationService = services[serviceName];
+		validator = validationService.buildCustomValidator(showErrorSpy);
 	});
 
 	describe('validate', (): void => {
 		it('should register a validation handler and use it to validate', (): void => {
-			var handler: IMockValidationHandler = {
+			let handler: IMockValidationHandler = {
 				validate: sinon.spy((): boolean => { return true; }),
 			};
 
-			validation.registerValidationHandler(<any>handler);
+			validator.registerValidationHandler(<any>handler);
 
-			var isValid: boolean = validation.validate();
+			let isValid: boolean = validator.validate();
 
 			sinon.assert.calledOnce(handler.validate);
 			expect(isValid).to.be.true;
 		});
 
-		it('should notify using the handler error message if validation fails', (): void => {
-			var handler: IMockValidationHandler = {
+		it('should show the handler\'s error message if validation fails', (): void => {
+			let handler: IMockValidationHandler = {
 				validate: sinon.spy((): boolean => { return false; }),
 				errorMessage: 'error',
 			};
 
-			validation.registerValidationHandler(<any>handler);
+			validator.registerValidationHandler(<any>handler);
 
-			var isValid: boolean = validation.validate();
+			let isValid: boolean = validator.validate();
 
 			sinon.assert.calledOnce(handler.validate);
 			expect(isValid).to.be.false;
-			sinon.assert.calledOnce(notification.warning);
-			sinon.assert.calledWith(notification.warning, 'error');
-		});
-
-		it('should use the error notification instead of warning if notifyAsError is set to true', (): void => {
-			var handler: IMockValidationHandler = {
-				validate: sinon.spy((): boolean => { return false; }),
-				errorMessage: 'error',
-			};
-
-			validation.registerValidationHandler(<any>handler);
-			validation.notifyAsError = true;
-
-			validation.validate();
-
-			sinon.assert.calledOnce(notification.error);
-			sinon.assert.calledWith(notification.error, 'error');
+			sinon.assert.calledOnce(showErrorSpy);
+			sinon.assert.calledWith(showErrorSpy, 'error');
 		});
 
 		it('should allow the handler to specify a function for returning the error message', (): void => {
-			var handler: IMockValidationHandler = {
+			let handler: IMockValidationHandler = {
 				validate: sinon.spy((): boolean => { return false; }),
 				errorMessage: sinon.spy((): string => { return 'error'; }),
 			};
 
-			validation.registerValidationHandler(<any>handler);
+			validator.registerValidationHandler(<any>handler);
 
-			validation.validate();
+			validator.validate();
 
 			sinon.assert.calledOnce(<Sinon.SinonSpy>handler.errorMessage);
 
@@ -106,31 +95,31 @@ describe('validation', () => {
 		});
 
 		it('should handle multiple validators and only show the error of the first one to fail', (): void => {
-			var firstValidHandler: IMockValidationHandler = {
+			let firstValidHandler: IMockValidationHandler = {
 				validate: sinon.spy((): boolean => { return true; }),
 			};
-			var secondValidHandler: IMockValidationHandler = {
+			let secondValidHandler: IMockValidationHandler = {
 				validate: sinon.spy((): boolean => { return true; }),
 			};
-			var firstFailingHandler: IMockValidationHandler = {
+			let firstFailingHandler: IMockValidationHandler = {
 				validate: sinon.spy((): boolean => { return false; }),
 				errorMessage: 'error1',
 			};
-			var thirdValidHandler: IMockValidationHandler = {
+			let thirdValidHandler: IMockValidationHandler = {
 				validate: sinon.spy((): boolean => { return true; }),
 			};
-			var secondFailingHandler: IMockValidationHandler = {
+			let secondFailingHandler: IMockValidationHandler = {
 				validate: sinon.spy((): boolean => { return false; }),
 				errorMessage: 'error2',
 			};
 
-			validation.registerValidationHandler(<any>firstValidHandler);
-			validation.registerValidationHandler(<any>secondValidHandler);
-			validation.registerValidationHandler(<any>firstFailingHandler);
-			validation.registerValidationHandler(<any>thirdValidHandler);
-			validation.registerValidationHandler(<any>secondFailingHandler);
+			validator.registerValidationHandler(<any>firstValidHandler);
+			validator.registerValidationHandler(<any>secondValidHandler);
+			validator.registerValidationHandler(<any>firstFailingHandler);
+			validator.registerValidationHandler(<any>thirdValidHandler);
+			validator.registerValidationHandler(<any>secondFailingHandler);
 
-			var isValid: boolean = validation.validate();
+			let isValid: boolean = validator.validate();
 
 			sinon.assert.calledOnce(firstFailingHandler.validate);
 			sinon.assert.calledOnce(secondValidHandler.validate);
@@ -147,14 +136,14 @@ describe('validation', () => {
 
 	describe('isActive', (): void => {
 		it('should disable a validator if isActive is set to false', (): void => {
-			var inactiveHandler: IMockValidationHandler = {
+			let inactiveHandler: IMockValidationHandler = {
 				validate: sinon.spy(),
 				isActive: false,
 			};
 
-			validation.registerValidationHandler(<any>inactiveHandler);
+			validator.registerValidationHandler(<any>inactiveHandler);
 
-			var isValid: boolean = validation.validate();
+			let isValid: boolean = validator.validate();
 
 			sinon.assert.notCalled(inactiveHandler.validate);
 			// defaults to true if no active validators
@@ -162,19 +151,19 @@ describe('validation', () => {
 		});
 
 		it('should call isActive and disable the validator if the result is false', (): void => {
-			var inactiveHandler: IMockValidationHandler = {
+			let inactiveHandler: IMockValidationHandler = {
 				validate: sinon.spy((): boolean => { return false; }),
 				isActive: sinon.spy((): boolean => { return false; }),
 			};
-			var activeHandler: IMockValidationHandler = {
+			let activeHandler: IMockValidationHandler = {
 				validate: sinon.spy((): boolean => { return true; }),
 				isActive: sinon.spy((): boolean => { return true; }),
 			};
 
-			validation.registerValidationHandler(<any>inactiveHandler);
-			validation.registerValidationHandler(<any>activeHandler);
+			validator.registerValidationHandler(<any>inactiveHandler);
+			validator.registerValidationHandler(<any>activeHandler);
 
-			var isValid: boolean = validation.validate();
+			let isValid: boolean = validator.validate();
 
 			sinon.assert.calledOnce(<Sinon.SinonSpy>inactiveHandler.isActive);
 			sinon.assert.notCalled(inactiveHandler.validate);
@@ -186,17 +175,17 @@ describe('validation', () => {
 
 	describe('unregister', (): void => {
 		it('should return a function to unregister the validation handler', (): void => {
-			var handlerToUnregister: IMockValidationHandler = {
+			let handlerToUnregister: IMockValidationHandler = {
 				validate: sinon.spy((): boolean => { return false; }),
 			};
-			var activeHandler: IMockValidationHandler = {
+			let activeHandler: IMockValidationHandler = {
 				validate: sinon.spy((): boolean => { return true; }),
 			};
 
-			var unregister: IUnregisterFunction = validation.registerValidationHandler(<any>handlerToUnregister);
-			validation.registerValidationHandler(<any>activeHandler);
+			let unregister: IUnregisterFunction = validator.registerValidationHandler(<any>handlerToUnregister);
+			validator.registerValidationHandler(<any>activeHandler);
 
-			var isValid: boolean = validation.validate();
+			let isValid: boolean = validator.validate();
 
 			expect(isValid).to.be.false;
 			sinon.assert.calledOnce(handlerToUnregister.validate);
@@ -207,11 +196,45 @@ describe('validation', () => {
 
 			unregister();
 
-			isValid = validation.validate();
+			isValid = validator.validate();
 
 			expect(isValid).to.be.true;
 			sinon.assert.notCalled(handlerToUnregister.validate);
 			sinon.assert.calledOnce(activeHandler.validate);
+		});
+	});
+
+	describe('notification', (): void => {
+		it('should show errors as error notifications', (): void => {
+			validator = validationService.buildNotificationErrorValidator();
+
+			let handler: IMockValidationHandler = {
+				validate: sinon.spy((): boolean => { return false; }),
+				errorMessage: 'error',
+			};
+
+			validator.registerValidationHandler(<any>handler);
+
+			validator.validate();
+
+			sinon.assert.calledOnce(notification.error);
+			sinon.assert.calledWith(notification.error, 'error');
+		});
+
+		it('should show errors as warning notifications', (): void => {
+			validator = validationService.buildNotificationWarningValidator();
+
+			let handler: IMockValidationHandler = {
+				validate: sinon.spy((): boolean => { return false; }),
+				errorMessage: 'error',
+			};
+
+			validator.registerValidationHandler(<any>handler);
+
+			validator.validate();
+
+			sinon.assert.calledOnce(notification.warning);
+			sinon.assert.calledWith(notification.warning, 'error');
 		});
 	});
 });

--- a/source/services/validation/validation.service.tests.ts
+++ b/source/services/validation/validation.service.tests.ts
@@ -90,8 +90,8 @@ describe('validation', () => {
 
 			sinon.assert.calledOnce(<Sinon.SinonSpy>handler.errorMessage);
 
-			sinon.assert.calledOnce(notification.warning);
-			sinon.assert.calledWith(notification.warning, 'error');
+			sinon.assert.calledOnce(showErrorSpy);
+			sinon.assert.calledWith(showErrorSpy, 'error');
 		});
 
 		it('should handle multiple validators and only show the error of the first one to fail', (): void => {
@@ -129,8 +129,8 @@ describe('validation', () => {
 			sinon.assert.notCalled(secondFailingHandler.validate);
 			expect(isValid).to.be.false;
 
-			sinon.assert.calledOnce(notification.warning);
-			sinon.assert.calledWith(notification.warning, 'error1');
+			sinon.assert.calledOnce(showErrorSpy);
+			sinon.assert.calledWith(showErrorSpy, 'error1');
 		});
 	});
 

--- a/source/services/validation/validation.service.ts
+++ b/source/services/validation/validation.service.ts
@@ -25,6 +25,7 @@ export interface IUnregisterFunction {
 export interface IValidationService {
 	validate(): boolean;
 	registerValidationHandler(handler: IValidationHandler): IUnregisterFunction;
+	isActive(handler: IValidationHandler): boolean;
 	notifyAsError: boolean;
 }
 
@@ -39,9 +40,7 @@ export class ValidationService implements IValidationService {
 		var isValid: boolean = true;
 
 		_.each(this.validationHandlers, (handler: IValidationHandler): boolean => {
-			var isActive: boolean = (_.isFunction(handler.isActive) && (<{(): boolean}>handler.isActive)())
-									|| handler.isActive == null
-									|| handler.isActive === true;
+			var isActive: boolean = this.isActive(handler);
 
 			if (isActive && !handler.validate()) {
 				isValid = false;
@@ -71,6 +70,12 @@ export class ValidationService implements IValidationService {
 		return (): void => {
 			this.unregister(currentKey);
 		};
+	}
+
+	isActive(handler: IValidationHandler): boolean {
+		return (_.isFunction(handler.isActive) && (<{(): boolean}>handler.isActive)())
+			|| handler.isActive == null
+			|| handler.isActive === true;
 	}
 
 	private unregister(key: number): void {

--- a/source/services/validation/validation.service.ts
+++ b/source/services/validation/validation.service.ts
@@ -9,8 +9,12 @@ import {
 	INotificationService,
 } from '../notification/notification.service';
 
+import { IValidator, Validator, IErrorHandler } from './validator';
+
+export { IUnregisterFunction, IValidator, IErrorHandler } from './validator';
+
 export var moduleName: string = 'rl.utilities.services.validation';
-export var factoryName: string = 'validationFactory';
+export var serviceName: string = 'validationFactory';
 
 export interface IValidationHandler {
 	isActive?: {(): boolean} | boolean;
@@ -18,90 +22,32 @@ export interface IValidationHandler {
 	errorMessage: string | {(): string};
 }
 
-export interface IUnregisterFunction {
-	(): void;
-}
-
 export interface IValidationService {
-	validate(): boolean;
-	registerValidationHandler(handler: IValidationHandler): IUnregisterFunction;
-	isActive(handler: IValidationHandler): boolean;
-	errorMessage(handler: IValidationHandler): string;
-	notifyAsError: boolean;
+	buildNotificationWarningValidator(): IValidator;
+	buildNotificationErrorValidator(): IValidator;
+	buildCustomValidator(showError: IErrorHandler): IValidator;
 }
 
 export class ValidationService implements IValidationService {
-	private validationHandlers: { [index: number]: IValidationHandler } = {};
-	private nextKey: number = 0;
-	notifyAsError: boolean = false;
+	static $inject: string[] = [notificationServiceName];
+	constructor(private notification: INotificationService) { }
 
-	constructor(private notification: INotificationService) {}
-
-	validate(): boolean {
-		var isValid: boolean = true;
-
-		_.each(this.validationHandlers, (handler: IValidationHandler): boolean => {
-			var isActive: boolean = this.isActive(handler);
-
-			if (isActive && !handler.validate()) {
-				isValid = false;
-
-				var error: string = this.errorMessage(handler);
-
-				if (this.notifyAsError) {
-					this.notification.error(error);
-				} else {
-					this.notification.warning(error);
-				}
-
-				return false;
-			}
+	buildNotificationWarningValidator(): IValidator {
+		return new Validator((error: string): void => {
+			this.notification.warning(error);
 		});
-
-		return isValid;
 	}
 
-	registerValidationHandler(handler: IValidationHandler): IUnregisterFunction {
-		var currentKey: number = this.nextKey;
-		this.nextKey++;
-		this.validationHandlers[currentKey] = handler;
-
-		return (): void => {
-			this.unregister(currentKey);
-		};
+	buildNotificationErrorValidator(): IValidator {
+		return new Validator((error: string): void => {
+			this.notification.error(error);
+		});
 	}
 
-	isActive(handler: IValidationHandler): boolean {
-		return (_.isFunction(handler.isActive) && (<{(): boolean}>handler.isActive)())
-			|| handler.isActive == null
-			|| handler.isActive === true;
+	buildCustomValidator(showError: IErrorHandler): IValidator {
+		return new Validator(showError);
 	}
-
-	errorMessage(handler: IValidationHandler): string {
-		return _.isFunction(handler.errorMessage)
-			? (<{ (): string }>handler.errorMessage)()
-			: <string>handler.errorMessage;
-	}
-
-	private unregister(key: number): void {
-		delete this.validationHandlers[key];
-	}
-}
-
-export interface IValidationServiceFactory {
-	getInstance(): IValidationService;
-}
-
-validationServiceFactory.$inject = [notificationServiceName];
-export function validationServiceFactory(notification: INotificationService): IValidationServiceFactory {
-	'use strict';
-
-	return {
-		getInstance(): IValidationService {
-			return new ValidationService(notification);
-		}
-	};
 }
 
 angular.module(moduleName, [notificationModuleName])
-	.factory(factoryName, validationServiceFactory);
+	.service(serviceName, ValidationService);

--- a/source/services/validation/validation.service.ts
+++ b/source/services/validation/validation.service.ts
@@ -10,10 +10,10 @@ import {
 } from '../notification/notification.service';
 
 import { IValidator, Validator, IErrorHandler } from './validator';
-import { IAggregateValidator, AggregateValidator } from './aggregateValidator';
+import { ICompositeValidator, CompositeValidator } from './compositeValidator';
 
 export { IUnregisterFunction, IValidator, IErrorHandler } from './validator';
-export { IAggregateValidator } from './aggregateValidator';
+export { ICompositeValidator } from './compositeValidator';
 
 export var moduleName: string = 'rl.utilities.services.validation';
 export var serviceName: string = 'validationFactory';
@@ -43,24 +43,24 @@ export interface IValidationService {
 	buildCustomValidator(showError: IErrorHandler): IValidator;
 
 	/**
-	* Build a validator that aggregates child validators
+	* Build a validator that groups child validators
 	* and uses warning notifications to show errors
 	*/
-	buildAggregateNotificationWarningValidator(): IAggregateValidator;
+	buildCompositeNotificationWarningValidator(): ICompositeValidator;
 
 	/**
-	* Build a validator that aggregates child validators
+	* Build a validator that groups child validators
 	* and uses error notifications to show errors
 	*/
-	buildAggregateNotificationErrorValidator(): IAggregateValidator;
+	buildCompositeNotificationErrorValidator(): ICompositeValidator;
 
 	/**
-	* Build a validator that aggregates child validators
+	* Build a validator that groups child validators
 	* and uses a custom handler to show errors
 	*
 	* @param showError A custom handler for validation errors
 	*/
-	buildAggregateCustomValidator(showError: IErrorHandler): IAggregateValidator;
+	buildCompositeCustomValidator(showError: IErrorHandler): ICompositeValidator;
 }
 
 export class ValidationService implements IValidationService {
@@ -83,20 +83,20 @@ export class ValidationService implements IValidationService {
 		return new Validator(showError);
 	}
 
-	buildAggregateNotificationWarningValidator(): IAggregateValidator {
-		return new AggregateValidator((error: string): void => {
+	buildCompositeNotificationWarningValidator(): ICompositeValidator {
+		return new CompositeValidator((error: string): void => {
 			this.notification.warning(error);
 		});
 	}
 
-	buildAggregateNotificationErrorValidator(): IAggregateValidator {
-		return new AggregateValidator((error: string): void => {
+	buildCompositeNotificationErrorValidator(): ICompositeValidator {
+		return new CompositeValidator((error: string): void => {
 			this.notification.error(error);
 		});
 	}
 
-	buildAggregateCustomValidator(showError: IErrorHandler): IAggregateValidator {
-		return new AggregateValidator(showError);
+	buildCompositeCustomValidator(showError: IErrorHandler): ICompositeValidator {
+		return new CompositeValidator(showError);
 	}
 }
 

--- a/source/services/validation/validation.service.ts
+++ b/source/services/validation/validation.service.ts
@@ -26,6 +26,7 @@ export interface IValidationService {
 	validate(): boolean;
 	registerValidationHandler(handler: IValidationHandler): IUnregisterFunction;
 	isActive(handler: IValidationHandler): boolean;
+	errorMessage(handler: IValidationHandler): string;
 	notifyAsError: boolean;
 }
 
@@ -45,9 +46,7 @@ export class ValidationService implements IValidationService {
 			if (isActive && !handler.validate()) {
 				isValid = false;
 
-				var error: string = _.isFunction(handler.errorMessage)
-									? (<{(): string}>handler.errorMessage)()
-									: <string>handler.errorMessage;
+				var error: string = this.errorMessage(handler);
 
 				if (this.notifyAsError) {
 					this.notification.error(error);
@@ -76,6 +75,12 @@ export class ValidationService implements IValidationService {
 		return (_.isFunction(handler.isActive) && (<{(): boolean}>handler.isActive)())
 			|| handler.isActive == null
 			|| handler.isActive === true;
+	}
+
+	errorMessage(handler: IValidationHandler): string {
+		return _.isFunction(handler.errorMessage)
+			? (<{ (): string }>handler.errorMessage)()
+			: <string>handler.errorMessage;
 	}
 
 	private unregister(key: number): void {

--- a/source/services/validation/validation.service.ts
+++ b/source/services/validation/validation.service.ts
@@ -10,8 +10,10 @@ import {
 } from '../notification/notification.service';
 
 import { IValidator, Validator, IErrorHandler } from './validator';
+import { IAggregateValidator, AggregateValidator } from './aggregateValidator';
 
 export { IUnregisterFunction, IValidator, IErrorHandler } from './validator';
+export { IAggregateValidator } from './aggregateValidator';
 
 export var moduleName: string = 'rl.utilities.services.validation';
 export var serviceName: string = 'validationFactory';
@@ -23,9 +25,42 @@ export interface IValidationHandler {
 }
 
 export interface IValidationService {
+	/**
+	* Build a validator that uses warning notifications to show errors
+	*/
 	buildNotificationWarningValidator(): IValidator;
+
+	/**
+	* Build a validator that uses error notifications to show errors
+	*/
 	buildNotificationErrorValidator(): IValidator;
+
+	/**
+	* Build a validator that uses a custom handler to show errors
+	*
+	* @param showError A custom handler for validation errors
+	*/
 	buildCustomValidator(showError: IErrorHandler): IValidator;
+
+	/**
+	* Build a validator that aggregates child validators
+	* and uses warning notifications to show errors
+	*/
+	buildAggregateNotificationWarningValidator(): IAggregateValidator;
+
+	/**
+	* Build a validator that aggregates child validators
+	* and uses error notifications to show errors
+	*/
+	buildAggregateNotificationErrorValidator(): IAggregateValidator;
+
+	/**
+	* Build a validator that aggregates child validators
+	* and uses a custom handler to show errors
+	*
+	* @param showError A custom handler for validation errors
+	*/
+	buildAggregateCustomValidator(showError: IErrorHandler): IAggregateValidator;
 }
 
 export class ValidationService implements IValidationService {
@@ -46,6 +81,22 @@ export class ValidationService implements IValidationService {
 
 	buildCustomValidator(showError: IErrorHandler): IValidator {
 		return new Validator(showError);
+	}
+
+	buildAggregateNotificationWarningValidator(): IAggregateValidator {
+		return new AggregateValidator((error: string): void => {
+			this.notification.warning(error);
+		});
+	}
+
+	buildAggregateNotificationErrorValidator(): IAggregateValidator {
+		return new AggregateValidator((error: string): void => {
+			this.notification.error(error);
+		});
+	}
+
+	buildAggregateCustomValidator(showError: IErrorHandler): IAggregateValidator {
+		return new AggregateValidator(showError);
 	}
 }
 

--- a/source/services/validation/validator.ts
+++ b/source/services/validation/validator.ts
@@ -18,7 +18,7 @@ export interface IErrorHandler {
 	(error: string): void;
 }
 
-export class Validator {
+export class Validator implements IValidator {
 	private validationHandlers: { [index: number]: IValidationHandler } = {};
 	private nextKey: number = 0;
 

--- a/source/services/validation/validator.ts
+++ b/source/services/validation/validator.ts
@@ -10,6 +10,7 @@ export interface IUnregisterFunction {
 
 export interface IValidator {
 	validate(): boolean;
+	getErrorCount(): number;
 	registerValidationHandler(handler: IValidationHandler): IUnregisterFunction;
 }
 
@@ -40,6 +41,18 @@ export class Validator {
 		});
 
 		return isValid;
+	}
+
+	getErrorCount(): number {
+		return _.reduce(<any>this.validationHandlers, (count: number, handler: IValidationHandler): number => {
+			var isActive: boolean = this.isActive(handler);
+
+			if (isActive && !handler.validate()) {
+				count++;
+			}
+
+			return count;
+		}, 0);
 	}
 
 	registerValidationHandler(handler: IValidationHandler): IUnregisterFunction {

--- a/source/services/validation/validator.ts
+++ b/source/services/validation/validator.ts
@@ -1,0 +1,70 @@
+'use strict';
+
+import * as _ from 'lodash';
+
+import { IValidationService, IValidationHandler } from './validation.service';
+
+export interface IUnregisterFunction {
+	(): void;
+}
+
+export interface IValidator {
+	validate(): boolean;
+	registerValidationHandler(handler: IValidationHandler): IUnregisterFunction;
+}
+
+export interface IErrorHandler {
+	(error: string): void;
+}
+
+export class Validator {
+	private validationHandlers: { [index: number]: IValidationHandler } = {};
+	private nextKey: number = 0;
+
+	constructor(private showError: IErrorHandler) {}
+
+	validate(): boolean {
+		let isValid: boolean = true;
+
+		_.each(this.validationHandlers, (handler: IValidationHandler): boolean => {
+			var isActive: boolean = this.isActive(handler);
+
+			if (isActive && !handler.validate()) {
+				isValid = false;
+
+				let error: string = this.errorMessage(handler);
+				this.showError(error);
+
+				return false;
+			}
+		});
+
+		return isValid;
+	}
+
+	registerValidationHandler(handler: IValidationHandler): IUnregisterFunction {
+		var currentKey: number = this.nextKey;
+		this.nextKey++;
+		this.validationHandlers[currentKey] = handler;
+
+		return (): void => {
+			this.unregister(currentKey);
+		};
+	}
+
+	private unregister(key: number): void {
+		delete this.validationHandlers[key];
+	}
+
+	private isActive(handler: IValidationHandler): boolean {
+		return (_.isFunction(handler.isActive) && (<{(): boolean}>handler.isActive)())
+			|| handler.isActive == null
+			|| handler.isActive === true;
+	}
+
+	private errorMessage(handler: IValidationHandler): string {
+		return _.isFunction(handler.errorMessage)
+			? (<{ (): string }>handler.errorMessage)()
+			: <string>handler.errorMessage;
+	}
+}


### PR DESCRIPTION
Implemented functionality for getting the count of failing handlers for a validator. Also implemented functionality for building aggregate validators. This is primarily used if we want to define subsets of the validator from which we can get the count separately.
