### PR TITLE
Child data services

### DIFF
--- a/source/services/dataContracts/baseDataService/baseDataServiceView.ts
+++ b/source/services/dataContracts/baseDataService/baseDataServiceView.ts
@@ -1,0 +1,8 @@
+'use strict';
+
+import { IBaseDataService, IBaseDomainObject } from './baseData.service';
+import { IBaseSingletonDataService } from '../baseSingletonDataService/baseSingletonData.service';
+
+export interface IBaseDataServiceView<TDataType extends IBaseDomainObject, TSearchParams> extends IBaseDataService<TDataType, TSearchParams> {
+	AsSingleton(parentId: number): IBaseSingletonDataService<TDataType>;
+}

--- a/source/services/dataContracts/baseParentDataService/baseParentData.service.tests.ts
+++ b/source/services/dataContracts/baseParentDataService/baseParentData.service.tests.ts
@@ -1,0 +1,109 @@
+/// <reference path='../../../../typings/chai/chai.d.ts' />
+/// <reference path='../../../../typings/sinon/sinon.d.ts' />
+/// <reference path='../../../../typings/mocha/mocha.d.ts' />
+/// <reference path='../../../../typings/chaiAssertions.d.ts' />
+
+'use strict';
+
+import { IBaseDataService } from '../baseDataService/baseData.service';
+import { IBaseDataServiceView } from '../baseDataService/baseDataServiceView';
+import { IBaseParentDataService } from './baseParentData.service';
+import { IBaseResourceBuilder, moduleName, serviceName } from '../baseResourceBuilder/baseResourceBuilder.service';
+
+import { angularFixture } from '../../test/angularFixture';
+
+import * as angular from 'angular';
+import 'angular-mocks';
+
+import * as _ from 'lodash';
+
+interface ITestResourceDictionaryType {
+	testView: IBaseDataServiceView<ITestMock, void>;
+	test: IBaseDataService<ITestMock, void>;
+}
+
+interface ITestMock {
+	id: number;
+	prop: string;
+}
+
+describe('base parent data service', () => {
+	let baseParentDataService: IBaseParentDataService<any, void, ITestResourceDictionaryType>;
+	let baseResourceBuilder: IBaseResourceBuilder;
+	let $rootScope: angular.IRootScopeService;
+	let dataSet: ITestMock[];
+	let dataService: IBaseDataService<ITestMock, void>;
+	let dataServiceView: IBaseDataServiceView<ITestMock, void>;
+
+	beforeEach((): void => {
+		angular.mock.module(moduleName);
+
+		dataSet = [
+			{ id: 1, prop: 'item1' },
+			{ id: 2, prop: 'item2' },
+			{ id: 3, prop: 'item3' },
+		];
+
+		let services: any = angularFixture.inject(serviceName, '$rootScope');
+		baseResourceBuilder = services[serviceName];
+		$rootScope = services.$rootScope;
+
+		dataService = baseResourceBuilder.createResource<ITestMock, void>({
+			mockData: dataSet,
+			useMock: true,
+		});
+		dataServiceView = baseResourceBuilder.createResourceView<ITestMock, void>({
+			mockData: dataSet,
+			useMock: true,
+		});
+
+		baseParentDataService = baseResourceBuilder.createParentResource<any, void, ITestResourceDictionaryType>({
+			resourceDictionaryBuilder(): ITestResourceDictionaryType {
+				return {
+					testView: dataServiceView,
+					test: dataService,
+				};
+			},
+		});
+	});
+
+	describe('viewAsSingleton', (): void => {
+		let children: ITestResourceDictionaryType;
+
+		beforeEach((): void => {
+			children = baseParentDataService.childContracts(1);
+		});
+
+		it('should wrap the child getDetail function and provide the id', (done: MochaDone): void => {
+			sinon.spy(dataServiceView, 'getDetail');
+			(<any>children.testView).get().then((item: ITestMock): void => {
+				expect(item).to.equal(dataSet[0]);
+				done();
+			});
+			sinon.assert.calledOnce(<Sinon.SinonSpy>dataServiceView.getDetail);
+			sinon.assert.calledWith(<Sinon.SinonSpy>dataServiceView.getDetail, 1);
+			$rootScope.$digest();
+		});
+
+		it('should expose the child update function', (): void => {
+			sinon.spy(dataServiceView, 'update');
+			(<any>children.testView).update(dataSet[0]);
+			sinon.assert.calledOnce(<Sinon.SinonSpy>dataServiceView.update);
+			sinon.assert.calledWith(<Sinon.SinonSpy>dataServiceView.update, dataSet[0]);
+		});
+
+		it('should disable getList, getDetail, and create', (): void => {
+			expect(children.testView.getList).to.not.exist;
+			expect(children.testView.getDetail).to.not.exist;
+			expect(children.testView.create).to.not.exist;
+		});
+
+		it('should leave standard data services untouched', (): void => {
+			expect(_.isFunction(children.test.getList)).to.be.true;
+			expect(_.isFunction(children.test.getDetail)).to.be.true;
+			expect(_.isFunction(children.test.create)).to.be.true;
+			expect(_.isFunction(children.test.update)).to.be.true;
+			expect((<any>children.test).get).to.not.exist;
+		});
+	});
+});

--- a/source/services/dataContracts/baseParentDataService/baseParentData.service.ts
+++ b/source/services/dataContracts/baseParentDataService/baseParentData.service.ts
@@ -26,7 +26,7 @@ export class BaseParentDataService<TDataType extends IBaseDomainObject, TSearchP
 			return this.resourceDictionaryBuilder(this.endpoint);
 		} else {
 			let dictionary: {[index: string]: any} = this.resourceDictionaryBuilder(this.endpoint + '/' + id);
-			_.map(dictionary, (dataService: IBaseDataServiceView<TDataType, TSearchParams>): IBaseSingletonDataService<TDataType> | IBaseDataService<TDataType, TSearchParams> => {
+			return <any>_.mapValues(dictionary, (dataService: IBaseDataServiceView<TDataType, TSearchParams>): IBaseSingletonDataService<TDataType> | IBaseDataService<TDataType, TSearchParams> => {
 				if (_.isFunction(dataService.AsSingleton)) {
 					return dataService.AsSingleton(id);
 				}

--- a/source/services/dataContracts/baseParentDataService/baseParentData.service.ts
+++ b/source/services/dataContracts/baseParentDataService/baseParentData.service.ts
@@ -3,10 +3,12 @@ import * as ng from 'angular';
 import { IArrayUtility } from '../../array/array.service';
 
 import { IBaseDataService, BaseDataService, IBaseDomainObject, ITransformFunction } from '../baseDataService/baseData.service';
+import { IBaseDataServiceView } from '../baseDataService/baseDataServiceView';
+import { IBaseSingletonDataService } from '../baseSingletonDataService/baseSingletonData.service';
 
 export interface IBaseParentDataService<TDataType extends IBaseDomainObject, TSearchParams, TResourceDictionaryType>
 	extends IBaseDataService<TDataType, TSearchParams>{
-	childContracts(id: number): TResourceDictionaryType;
+	childContracts(id?: number): TResourceDictionaryType;
 }
 
 export class BaseParentDataService<TDataType extends IBaseDomainObject, TSearchParams, TResourceDictionaryType>
@@ -19,7 +21,17 @@ export class BaseParentDataService<TDataType extends IBaseDomainObject, TSearchP
 		super($http, $q, array, endpoint, mockData, transform, useMock, logRequests);
 	}
 
-	childContracts(id: number): TResourceDictionaryType {
-		return this.resourceDictionaryBuilder(this.endpoint + '/' + id);
+	childContracts(id?: number): TResourceDictionaryType {
+		if (_.isUndefined(id)) {
+			return this.resourceDictionaryBuilder(this.endpoint);
+		} else {
+			let dictionary: {[index: string]: any} = this.resourceDictionaryBuilder(this.endpoint + '/' + id);
+			_.map(dictionary, (dataService: IBaseDataServiceView<TDataType, TSearchParams>): IBaseSingletonDataService<TDataType> | IBaseDataService<TDataType, TSearchParams> => {
+				if (_.isFunction(dataService.AsSingleton)) {
+					return dataService.AsSingleton(id);
+				}
+				return dataService;
+			});
+		}
 	}
 }

--- a/source/services/dataContracts/baseResourceBuilder/baseResourceBuilder.service.ts
+++ b/source/services/dataContracts/baseResourceBuilder/baseResourceBuilder.service.ts
@@ -163,6 +163,7 @@ export class BaseResourceBuilder implements IBaseResourceBuilder {
 				logRequests: dataServiceView.logRequests,
 			};
 		}
+		return dataServiceView;
 	}
 
 	createParentResource<TDataType extends IBaseDomainObject, TSearchParams, TResourceDictionaryType>

--- a/source/services/dataContracts/baseResourceBuilder/baseResourceBuilder.service.ts
+++ b/source/services/dataContracts/baseResourceBuilder/baseResourceBuilder.service.ts
@@ -6,6 +6,7 @@ import { IArrayUtility, serviceName as arrayServiceName, moduleName as arrayModu
 
 import { IContractLibrary, ContractLibrary, ILibraryServices } from './contractLibrary';
 import { IBaseDataService, BaseDataService, IBaseDomainObject, ITransformFunction } from '../baseDataService/baseData.service';
+import { IBaseDataServiceView } from '../baseDataService/baseDataServiceView';
 import { IBaseParentDataService, BaseParentDataService } from '../baseParentDataService/baseParentData.service';
 import { IBaseSingletonDataService, BaseSingletonDataService } from '../baseSingletonDataService/baseSingletonData.service';
 import { IBaseParentSingletonDataService, BaseParentSingletonDataService } from '../baseParentSingletonDataService/baseParentSingletonData.service';
@@ -100,6 +101,17 @@ export interface IBaseResourceBuilder {
 	createResource<TDataType extends IBaseDomainObject>(options: IBaseResourceParams<TDataType>): IBaseDataService<TDataType, void>;
 
 	/**
+	* Create a view of a parent resource that can be used as a base resource or
+	* as a singleton if a parent is selected
+	*/
+	createResourceView<TDataType extends IBaseDomainObject, TSearchParams>(options: IBaseResourceParams<TDataType>): IBaseDataServiceView<TDataType, TSearchParams>;
+	/**
+	* Create a view of a parent resource that can be used as a base resource or
+	* as a singleton if a parent is selected
+	*/
+	createResourceView<TDataType extends IBaseDomainObject>(options: IBaseResourceParams<TDataType>): IBaseDataServiceView<TDataType, void>;
+
+	/**
 	* Create a parent resource that extends the standard with child resources available through childContracts(id)
 	*/
 	createParentResource<TDataType extends IBaseDomainObject, TSearchParams, TResourceDictionaryType>
@@ -111,12 +123,12 @@ export interface IBaseResourceBuilder {
 		(options: IParentResourceParams<TDataType, TResourceDictionaryType>): IBaseParentDataService<TDataType, void, TResourceDictionaryType>;
 
 	/**
-	* Create a singleton resource with get and update
+	* Deprecated - Create a singleton resource with get and update
 	*/
 	createSingletonResource<TDataType>(options: ISingletonResourceParams<TDataType>): IBaseSingletonDataService<TDataType>;
 
 	/**
-	* Create a parent singleton resource that extends the singleton with child resources available through childContracts(id)
+	* Deprecated - Create a parent singleton resource that extends the singleton with child resources available through childContracts(id)
 	*/
 	createParentSingletonResource<TDataType, TResourceDictionaryType>
 		(options: IParentSingletonResourceParams<TDataType, TResourceDictionaryType>): IBaseParentSingletonDataService<TDataType, TResourceDictionaryType>;
@@ -139,6 +151,18 @@ export class BaseResourceBuilder implements IBaseResourceBuilder {
 	createResource<TDataType extends IBaseDomainObject, TSearchParams>(options: IBaseResourceParams<TDataType>): IBaseDataService<TDataType, TSearchParams> {
 		options.useMock = options.endpoint == null ? true : options.useMock;
 		return new BaseDataService(this.$http, this.$q, this.array, options.endpoint, options.mockData, options.transform, options.useMock, options.logRequests);
+	}
+
+	createResourceView<TDataType extends IBaseDomainObject, TSearchParams>(options: IBaseResourceParams<TDataType>): IBaseDataServiceView<TDataType, TSearchParams> {
+		let dataServiceView: IBaseDataServiceView<TDataType, TSearchParams> = <any>this.createResource(options);
+		dataServiceView.AsSingleton = function(parentId: number): IBaseSingletonDataService<TDataType> {
+			return {
+				get(): angular.IPromise<TDataType> { return dataServiceView.getDetail(parentId); },
+				update(domainObject: TDataType): angular.IPromise<void> { return dataServiceView.update(domainObject); },
+				useMock: dataServiceView.useMock,
+				logRequests: dataServiceView.logRequests,
+			};
+		}
 	}
 
 	createParentResource<TDataType extends IBaseDomainObject, TSearchParams, TResourceDictionaryType>

--- a/source/services/dataContracts/dataContracts.module.ts
+++ b/source/services/dataContracts/dataContracts.module.ts
@@ -10,6 +10,7 @@ export var moduleName: string = 'rl.utilities.services.dataContracts';
 
 export * from './baseResourceBuilder/contractLibrary';
 export { IBaseDataService, IBaseDataServiceFactory, IBaseDomainObject, BaseDataService, factoryName as baseDataServiceFactoryName } from './baseDataService/baseData.service';
+export { IBaseDataServiceView } from './baseDataService/baseDataServiceView';
 export * from './baseParentDataService/baseParentData.service';
 export { IBaseSingletonDataService, IBaseSingletonDataServiceFactory, BaseSingletonDataService, factoryName as baseSingletonDataServiceFactoryName } from './baseSingletonDataService/baseSingletonData.service';
 export * from './baseParentSingletonDataService/baseParentSingletonData.service';


### PR DESCRIPTION
Added the ability to specify a resource view. This resource type is considered a base data service if no id is passed to the parent's childContracts function. Otherwise, it is converted to a singleton.
