### PR TITLE
Resource changes

### DIFF
--- a/source/services/dataContracts/baseDataService/baseDataServiceView.ts
+++ b/source/services/dataContracts/baseDataService/baseDataServiceView.ts
@@ -1,8 +1,15 @@
 'use strict';
 
 import { IBaseDataService, IBaseDomainObject } from './baseData.service';
+import { IBaseParentDataService } from '../baseParentDataService/baseParentData.service';
 import { IBaseSingletonDataService } from '../baseSingletonDataService/baseSingletonData.service';
+import { IBaseParentSingletonDataService } from '../baseParentSingletonDataService/baseParentSingletonData.service';
 
 export interface IBaseDataServiceView<TDataType extends IBaseDomainObject, TSearchParams> extends IBaseDataService<TDataType, TSearchParams> {
 	AsSingleton(parentId: number): IBaseSingletonDataService<TDataType>;
+}
+
+export interface IBaseParentDataServiceView<TDataType extends IBaseDomainObject, TSearchParams, TResourceDictionaryType>
+	extends IBaseParentDataService<TDataType, TSearchParams, TResourceDictionaryType>{
+	AsSingleton(parentId: number): IBaseParentSingletonDataService<TDataType, TResourceDictionaryType>;
 }

--- a/source/services/dataContracts/baseParentDataService/baseParentData.service.ts
+++ b/source/services/dataContracts/baseParentDataService/baseParentData.service.ts
@@ -13,24 +13,36 @@ export interface IBaseParentDataService<TDataType extends IBaseDomainObject, TSe
 
 export class BaseParentDataService<TDataType extends IBaseDomainObject, TSearchParams, TResourceDictionaryType>
 	extends BaseDataService<TDataType, TSearchParams> implements IBaseParentDataService<TDataType, TSearchParams, TResourceDictionaryType> {
+	private _childContracts: TResourceDictionaryType;
+
 	constructor($http: ng.IHttpService, $q: ng.IQService, array: IArrayUtility, endpoint: string, mockData: TDataType[]
-		, private resourceDictionaryBuilder: { (baseEndpoint: string): TResourceDictionaryType }
+		, private resourceDictionaryBuilder: { (): TResourceDictionaryType }
 		, transform?: ITransformFunction<TDataType>
 		, useMock?: boolean
         , logRequests?: boolean) {
 		super($http, $q, array, endpoint, mockData, transform, useMock, logRequests);
+		this._childContracts = this.resourceDictionaryBuilder();
 	}
 
 	childContracts(id?: number): TResourceDictionaryType {
 		if (_.isUndefined(id)) {
-			return this.resourceDictionaryBuilder(this.endpoint);
+			return <any>_.mapValues(this._childContracts, (dataService: any): IBaseDataService<TDataType, TSearchParams> => {
+				let contract: any = dataService.clone();
+				contract.endpoint = this.endpoint + contract.endpoint;
+				return contract;
+			});
 		} else {
-			let dictionary: {[index: string]: any} = this.resourceDictionaryBuilder(this.endpoint + '/' + id);
+			let dictionary: {[index: string]: any} = this._childContracts;
 			return <any>_.mapValues(dictionary, (dataService: IBaseDataServiceView<TDataType, TSearchParams>): IBaseSingletonDataService<TDataType> | IBaseDataService<TDataType, TSearchParams> => {
-				if (_.isFunction(dataService.AsSingleton)) {
-					return dataService.AsSingleton(id);
+				let contract: any = dataService;
+
+				if (_.isFunction(contract.AsSingleton)) {
+					contract = contract.AsSingleton(id);
+				} else {
+					contract = contract.clone();
 				}
-				return dataService;
+				contract.endpoint = this.endpoint + '/' + id + contract.endpoint;
+				return contract;
 			});
 		}
 	}

--- a/source/services/dataContracts/baseParentDataService/baseParentData.service.ts
+++ b/source/services/dataContracts/baseParentDataService/baseParentData.service.ts
@@ -9,7 +9,7 @@ import { IBaseSingletonDataService } from '../baseSingletonDataService/baseSingl
 export interface IBaseParentDataService<TDataType extends IBaseDomainObject, TSearchParams, TResourceDictionaryType>
 	extends IBaseDataService<TDataType, TSearchParams>{
 	childContracts(id?: number): TResourceDictionaryType;
-	baseChildContracts(): TResourceDictionaryType;
+	baseChildContracts: TResourceDictionaryType;
 }
 
 export class BaseParentDataService<TDataType extends IBaseDomainObject, TSearchParams, TResourceDictionaryType>
@@ -48,7 +48,7 @@ export class BaseParentDataService<TDataType extends IBaseDomainObject, TSearchP
 		}
 	}
 
-	baseChildContracts(): TResourceDictionaryType {
+	get baseChildContracts(): TResourceDictionaryType {
 		return this._childContracts;
 	}
 }

--- a/source/services/dataContracts/baseParentDataService/baseParentData.service.ts
+++ b/source/services/dataContracts/baseParentDataService/baseParentData.service.ts
@@ -9,6 +9,7 @@ import { IBaseSingletonDataService } from '../baseSingletonDataService/baseSingl
 export interface IBaseParentDataService<TDataType extends IBaseDomainObject, TSearchParams, TResourceDictionaryType>
 	extends IBaseDataService<TDataType, TSearchParams>{
 	childContracts(id?: number): TResourceDictionaryType;
+	baseChildContracts(): TResourceDictionaryType;
 }
 
 export class BaseParentDataService<TDataType extends IBaseDomainObject, TSearchParams, TResourceDictionaryType>
@@ -45,5 +46,9 @@ export class BaseParentDataService<TDataType extends IBaseDomainObject, TSearchP
 				return contract;
 			});
 		}
+	}
+
+	baseChildContracts(): TResourceDictionaryType {
+		return this._childContracts;
 	}
 }

--- a/source/services/dataContracts/baseResourceBuilder/baseResourceBuilder.service.ts
+++ b/source/services/dataContracts/baseResourceBuilder/baseResourceBuilder.service.ts
@@ -198,6 +198,16 @@ export class BaseResourceBuilder implements IBaseResourceBuilder {
 			logRequests: castedResource.logRequests,
 		};
 	}
+
+	private cloneSingletonResource<TDataType>(resource: IBaseSingletonDataService<TDataType>): IBaseSingletonDataService<TDataType> {
+		let castedResource: BaseSingletonDataService<TDataType> = <BaseSingletonDataService<TDataType>>resource;
+		return {
+			get(): angular.IPromise<TDataType> { return castedResource.get(endpoint); },
+			update(domainObject: TDataType): angular.IPromise<void> { return castedResource.update(domainObject, endpoint); },
+			useMock: castedResource.useMock,
+			logRequests: castedResource.logRequests,
+		};
+	}
 }
 
 angular.module(moduleName, [arrayModuleName])

--- a/source/services/dataContracts/baseSingletonDataService/baseSingletonData.service.ts
+++ b/source/services/dataContracts/baseSingletonDataService/baseSingletonData.service.ts
@@ -29,12 +29,12 @@ export class BaseSingletonDataService<TDataType> implements IBaseSingletonDataSe
         return this._endpoint;
     }
 
-    get(): angular.IPromise<TDataType> {
+    get(endpoint?: string): angular.IPromise<TDataType> {
         let promise: angular.IPromise<TDataType>;
         if (this.useMock) {
             promise = this.$q.when(this.mockData);
         } else {
-            promise = this.$http.get(this.endpoint)
+            promise = this.$http.get(this.getEndpointOrDefault(endpoint))
                 .then((response: angular.IHttpPromiseCallbackArg<TDataType>): TDataType => {
                 return response.data;
             });
@@ -50,13 +50,13 @@ export class BaseSingletonDataService<TDataType> implements IBaseSingletonDataSe
         });
     }
 
-    update(domainObject: TDataType): angular.IPromise<void> {
+    update(domainObject: TDataType, endpoint?: string): angular.IPromise<void> {
         let promise: angular.IPromise<void>;
         if (this.useMock) {
             this.mockData = <TDataType>_.assign(this.mockData, domainObject);
             promise = this.$q.when();
         } else {
-            promise = this.$http.put<void>(this.endpoint, domainObject).then((): void => { return null; });
+            promise = this.$http.put<void>(this.getEndpointOrDefault(endpoint), domainObject).then((): void => { return null; });
         }
         return promise.then((): void => {
             if (this.logRequests) {
@@ -70,6 +70,10 @@ export class BaseSingletonDataService<TDataType> implements IBaseSingletonDataSe
         let endpointString = this.endpoint == null ? 'unspecified' : this.endpoint;
         console.log(mockString + requestName + ' for endpoint ' + endpointString + ':');
         console.log(data);
+    }
+
+    private getEndpointOrDefault(endpoint?: string): string {
+        return endpoint != null ? endpoint : this.endpoint;
     }
 }
 

--- a/source/services/dataContracts/dataContracts.module.ts
+++ b/source/services/dataContracts/dataContracts.module.ts
@@ -10,7 +10,7 @@ export var moduleName: string = 'rl.utilities.services.dataContracts';
 
 export * from './baseResourceBuilder/contractLibrary';
 export { IBaseDataService, IBaseDataServiceFactory, IBaseDomainObject, BaseDataService, factoryName as baseDataServiceFactoryName } from './baseDataService/baseData.service';
-export { IBaseDataServiceView } from './baseDataService/baseDataServiceView';
+export { IBaseDataServiceView, IBaseParentDataServiceView } from './baseDataService/baseDataServiceView';
 export * from './baseParentDataService/baseParentData.service';
 export { IBaseSingletonDataService, IBaseSingletonDataServiceFactory, BaseSingletonDataService, factoryName as baseSingletonDataServiceFactoryName } from './baseSingletonDataService/baseSingletonData.service';
 export * from './baseParentSingletonDataService/baseParentSingletonData.service';

--- a/source/services/services.module.ts
+++ b/source/services/services.module.ts
@@ -3,8 +3,6 @@
 import * as angular from 'angular';
 
 import * as array from './array/array.service';
-import * as autosave from './autosave/autosave.service';
-import * as autosaveAction from './autosaveAction/autosaveAction.service';
 import * as boolean from './boolean/boolean.service';
 import * as dataContracts from './dataContracts/dataContracts.module';
 import * as date from './date/date.module';
@@ -26,8 +24,6 @@ import * as validation from './validation/validation.service';
 
 export {
 	array,
-	autosave,
-	autosaveAction,
 	boolean,
 	dataContracts,
 	date,
@@ -52,8 +48,6 @@ export var moduleName: string = 'rl.utilities.services';
 
 angular.module(moduleName, [
 	array.moduleName,
-	autosave.moduleName,
-	autosaveAction.moduleName,
 	boolean.moduleName,
 	dataContracts.moduleName,
 	date.moduleName,


### PR DESCRIPTION
Improvements to the contracts library to support mocking child resources. In order to do this, we have to build the child resources up front and make them available to be mocked. Since the endpoint will likely need to change depending on whether a parent id is specified or not, the childContracts() function will return 'views' of the child resources by passing the call on to the base with a custom endpoint.

**Requires a minor version update**
Consumers no longer need to append child endpoints to the base endpoint. This is now handled internally in the parent data service.
