### PR TITLE
Cleanup data contracts

### DIFF
--- a/source/services/dataContracts/baseDataService/baseData.service.ts
+++ b/source/services/dataContracts/baseDataService/baseData.service.ts
@@ -28,12 +28,12 @@ export interface IBaseDataService<TDataType extends IBaseDomainObject, TSearchPa
 }
 
 export class BaseDataService<TDataType extends IBaseDomainObject, TSearchParams> implements IBaseDataService<TDataType, TSearchParams> {
-    constructor(private $http: angular.IHttpService
-            , private $q: angular.IQService
-            , private array: IArrayUtility
-            , private _endpoint: string
-            , private mockData: TDataType[]
-            , private transform: ITransformFunction<TDataType>
+    constructor(protected $http: angular.IHttpService
+            , protected $q: angular.IQService
+            , protected array: IArrayUtility
+            , protected _endpoint: string
+            , protected mockData: TDataType[]
+            , protected transform: ITransformFunction<TDataType>
             , public useMock: boolean
             , public logRequests: boolean) { }
 

--- a/source/services/dataContracts/baseDataService/baseData.service.ts
+++ b/source/services/dataContracts/baseDataService/baseData.service.ts
@@ -41,17 +41,16 @@ export class BaseDataService<TDataType extends IBaseDomainObject, TSearchParams>
         return this._endpoint;
     }
 
-    private getItemEndpoint(id: number, endpoint?: string): string {
-        let targetEndpoint: string = this.getEndpointOrDefault(endpoint);
-        return targetEndpoint + '/' + id.toString();
+    private getItemEndpoint(id: number): string {
+        return this.endpoint + '/' + id.toString();
     }
 
-    getList(params: TSearchParams, endpoint?: string): angular.IPromise<TDataType[]> {
+    getList(params: TSearchParams): angular.IPromise<TDataType[]> {
         let promise: angular.IPromise<TDataType[]>;
         if (this.useMock) {
             promise = this.$q.when(this.mockData);
         } else {
-            promise = this.$http.get(this.getEndpointOrDefault(endpoint), { params: params })
+            promise = this.$http.get(this.endpoint, { params: params })
                 .then((response: angular.IHttpPromiseCallbackArg<TDataType[]>): TDataType[] => {
                 return response.data;
             });
@@ -67,14 +66,14 @@ export class BaseDataService<TDataType extends IBaseDomainObject, TSearchParams>
         })
     }
 
-    getDetail(id: number, endpoint?: string): angular.IPromise<TDataType> {
+    getDetail(id: number): angular.IPromise<TDataType> {
         let promise: angular.IPromise<TDataType>;
         if (this.useMock) {
             promise = this.$q.when(_.find(this.mockData, (item: TDataType): boolean => {
                 return item.id === id;
             }));
         } else {
-            promise = this.$http.get(this.getItemEndpoint(id, endpoint))
+            promise = this.$http.get(this.getItemEndpoint(id))
                 .then((response: angular.IHttpPromiseCallbackArg<TDataType>): TDataType => {
                 return response.data;
             });
@@ -90,7 +89,7 @@ export class BaseDataService<TDataType extends IBaseDomainObject, TSearchParams>
         });
     }
 
-    create(domainObject: TDataType, endpoint?: string): angular.IPromise<TDataType> {
+    create(domainObject: TDataType): angular.IPromise<TDataType> {
         let promise: angular.IPromise<TDataType>;
         if (this.useMock) {
             let nextId: number = _.max(this.mockData, 'id').id + 1;
@@ -98,7 +97,7 @@ export class BaseDataService<TDataType extends IBaseDomainObject, TSearchParams>
             this.mockData.push(domainObject);
             promise = this.$q.when(domainObject);
         } else {
-            promise = this.$http.post(this.getEndpointOrDefault(endpoint), JSON.stringify(domainObject))
+            promise = this.$http.post(this.endpoint, JSON.stringify(domainObject))
                 .then((result: angular.IHttpPromiseCallbackArg<TDataType>): TDataType => {
                 return result.data;
             });
@@ -111,7 +110,7 @@ export class BaseDataService<TDataType extends IBaseDomainObject, TSearchParams>
         });
     }
 
-    update(domainObject: TDataType, endpoint?: string): angular.IPromise<void> {
+    update(domainObject: TDataType): angular.IPromise<void> {
         let promise: angular.IPromise<void>;
         if (this.useMock) {
             let oldObject: TDataType = _.find(this.mockData, _.find(this.mockData, (item: TDataType): boolean => {
@@ -120,7 +119,7 @@ export class BaseDataService<TDataType extends IBaseDomainObject, TSearchParams>
             oldObject = <TDataType>_.assign(oldObject, domainObject);
             promise = this.$q.when();
         } else {
-            promise = this.$http.put<void>(this.getItemEndpoint(domainObject.id, endpoint), domainObject).then((): void => { return null; });
+            promise = this.$http.put<void>(this.getItemEndpoint(domainObject.id), domainObject).then((): void => { return null; });
         }
         return promise.then((): void => {
             if (this.logRequests) {
@@ -129,13 +128,13 @@ export class BaseDataService<TDataType extends IBaseDomainObject, TSearchParams>
         });
     }
 
-    delete(domainObject: TDataType, endpoint?: string): angular.IPromise<void> {
+    delete(domainObject: TDataType): angular.IPromise<void> {
         let promise: angular.IPromise<void>;
         if (this.useMock) {
             this.array.remove(this.mockData, domainObject);
             promise = this.$q.when();
         } else {
-            promise = this.$http.delete<void>(this.getItemEndpoint(domainObject.id, endpoint)).then((): void => { return null; });
+            promise = this.$http.delete<void>(this.getItemEndpoint(domainObject.id)).then((): void => { return null; });
         }
         return promise.then((): void => {
             if (this.logRequests) {
@@ -149,10 +148,6 @@ export class BaseDataService<TDataType extends IBaseDomainObject, TSearchParams>
         let endpointString = this.endpoint == null ? 'unspecified' : this.endpoint;
         console.log(mockString + requestName + ' for endpoint ' + endpointString + ':');
         console.log(data);
-    }
-
-    private getEndpointOrDefault(endpoint?: string): string {
-        return endpoint != null ? endpoint : this.endpoint;
     }
 }
 

--- a/source/services/dataContracts/baseDataService/baseDataServiceView.ts
+++ b/source/services/dataContracts/baseDataService/baseDataServiceView.ts
@@ -11,6 +11,9 @@ export interface IBaseDataServiceView<TDataType extends IBaseDomainObject, TSear
 	AsSingleton(parentId: number): IBaseSingletonDataService<TDataType>;
 }
 
+export interface IBaseParentDataServiceView<TDataType extends IBaseDomainObject, TSearchParams, TResourceDictionaryType>
+	extends IBaseParentDataService<TDataType, TSearchParams, TResourceDictionaryType>{
+	AsSingleton(parentId: number): IBaseParentSingletonDataService<TDataType, TResourceDictionaryType>;
 }
 
 export class BaseDataServiceView<TDataType extends IBaseDomainObject, TSearchParams>
@@ -56,3 +59,4 @@ export class BaseParentDataServiceView<TDataType extends IBaseDomainObject, TSea
 		});
 		return new BaseParentSingletonDataService<TDataType, TResourceDictionaryType>(this.$http, this.$q, this.endpoint, mockData, this.resourceDictionaryBuilder, this.transform, this.useMock, this.logRequests);
 	}
+}

--- a/source/services/dataContracts/baseDataService/baseDataServiceView.ts
+++ b/source/services/dataContracts/baseDataService/baseDataServiceView.ts
@@ -11,9 +11,6 @@ export interface IBaseDataServiceView<TDataType extends IBaseDomainObject, TSear
 	AsSingleton(parentId: number): IBaseSingletonDataService<TDataType>;
 }
 
-export interface IBaseParentDataServiceView<TDataType extends IBaseDomainObject, TSearchParams, TResourceDictionaryType>
-	extends IBaseParentDataService<TDataType, TSearchParams, TResourceDictionaryType>{
-	AsSingleton(parentId: number): IBaseParentSingletonDataService<TDataType, TResourceDictionaryType>;
 }
 
 export class BaseDataServiceView<TDataType extends IBaseDomainObject, TSearchParams>
@@ -59,4 +56,3 @@ export class BaseParentDataServiceView<TDataType extends IBaseDomainObject, TSea
 		});
 		return new BaseParentSingletonDataService<TDataType, TResourceDictionaryType>(this.$http, this.$q, this.endpoint, mockData, this.resourceDictionaryBuilder, this.transform, this.useMock, this.logRequests);
 	}
-}

--- a/source/services/dataContracts/baseDataService/baseDataServiceView.ts
+++ b/source/services/dataContracts/baseDataService/baseDataServiceView.ts
@@ -1,9 +1,11 @@
 'use strict';
 
-import { IBaseDataService, IBaseDomainObject } from './baseData.service';
-import { IBaseParentDataService } from '../baseParentDataService/baseParentData.service';
-import { IBaseSingletonDataService } from '../baseSingletonDataService/baseSingletonData.service';
-import { IBaseParentSingletonDataService } from '../baseParentSingletonDataService/baseParentSingletonData.service';
+import { IArrayUtility, serviceName as arrayServiceName, moduleName as arrayModuleName } from '../../array/array.service';
+
+import { IBaseDataService, BaseDataService, IBaseDomainObject, ITransformFunction } from './baseData.service';
+import { IBaseParentDataService, BaseParentDataService } from '../baseParentDataService/baseParentData.service';
+import { IBaseSingletonDataService, BaseSingletonDataService } from '../baseSingletonDataService/baseSingletonData.service';
+import { IBaseParentSingletonDataService, BaseParentSingletonDataService } from '../baseParentSingletonDataService/baseParentSingletonData.service';
 
 export interface IBaseDataServiceView<TDataType extends IBaseDomainObject, TSearchParams> extends IBaseDataService<TDataType, TSearchParams> {
 	AsSingleton(parentId: number): IBaseSingletonDataService<TDataType>;
@@ -12,4 +14,49 @@ export interface IBaseDataServiceView<TDataType extends IBaseDomainObject, TSear
 export interface IBaseParentDataServiceView<TDataType extends IBaseDomainObject, TSearchParams, TResourceDictionaryType>
 	extends IBaseParentDataService<TDataType, TSearchParams, TResourceDictionaryType>{
 	AsSingleton(parentId: number): IBaseParentSingletonDataService<TDataType, TResourceDictionaryType>;
+}
+
+export class BaseDataServiceView<TDataType extends IBaseDomainObject, TSearchParams>
+	extends BaseDataService<TDataType, TSearchParams>
+	implements IBaseDataServiceView<TDataType, TSearchParams> {
+    constructor($http: angular.IHttpService
+            , $q: angular.IQService
+            , array: IArrayUtility
+            , _endpoint: string
+            , mockData: TDataType[]
+            , transform: ITransformFunction<TDataType>
+            , useMock: boolean
+            , logRequests: boolean) {
+		super($http, $q, array, _endpoint, mockData, transform, useMock, logRequests);
+	}
+
+	AsSingleton(parentId: number): IBaseSingletonDataService<TDataType> {
+		let mockData: TDataType = _.find(this.mockData, (item: TDataType): boolean => {
+			return item.id === parentId;
+		});
+		return new BaseSingletonDataService<TDataType>(this.$http, this.$q, this.endpoint, mockData, this.transform, this.useMock, this.logRequests);
+	}
+}
+
+export class BaseParentDataServiceView<TDataType extends IBaseDomainObject, TSearchParams, TResourceDictionaryType>
+	extends BaseParentDataService<TDataType, TSearchParams, TResourceDictionaryType>
+	implements IBaseParentDataServiceView<TDataType, TSearchParams, TResourceDictionaryType> {
+    constructor($http: angular.IHttpService
+            , $q: angular.IQService
+            , array: IArrayUtility
+            , _endpoint: string
+            , mockData: TDataType[]
+			, resourceDictionaryBuilder: {(): TResourceDictionaryType}
+            , transform: ITransformFunction<TDataType>
+            , useMock: boolean
+            , logRequests: boolean) {
+		super($http, $q, array, _endpoint, mockData, resourceDictionaryBuilder, transform, useMock, logRequests);
+	}
+
+	AsSingleton(parentId: number): IBaseParentSingletonDataService<TDataType, TResourceDictionaryType> {
+		let mockData: TDataType = _.find(this.mockData, (item: TDataType): boolean => {
+			return item.id === parentId;
+		});
+		return new BaseParentSingletonDataService<TDataType, TResourceDictionaryType>(this.$http, this.$q, this.endpoint, mockData, this.resourceDictionaryBuilder, this.transform, this.useMock, this.logRequests);
+	}
 }

--- a/source/services/dataContracts/baseParentDataService/baseParentData.service.ts
+++ b/source/services/dataContracts/baseParentDataService/baseParentData.service.ts
@@ -9,7 +9,6 @@ import { IBaseSingletonDataService } from '../baseSingletonDataService/baseSingl
 export interface IBaseParentDataService<TDataType extends IBaseDomainObject, TSearchParams, TResourceDictionaryType>
 	extends IBaseDataService<TDataType, TSearchParams>{
 	childContracts(id?: number): TResourceDictionaryType;
-	baseChildContracts(): TResourceDictionaryType;
 }
 
 export class BaseParentDataService<TDataType extends IBaseDomainObject, TSearchParams, TResourceDictionaryType>
@@ -46,9 +45,5 @@ export class BaseParentDataService<TDataType extends IBaseDomainObject, TSearchP
 				return contract;
 			});
 		}
-	}
-
-	baseChildContracts(): TResourceDictionaryType {
-		return this._childContracts;
 	}
 }

--- a/source/services/dataContracts/baseParentDataService/baseParentData.service.ts
+++ b/source/services/dataContracts/baseParentDataService/baseParentData.service.ts
@@ -14,7 +14,7 @@ export interface IBaseParentDataService<TDataType extends IBaseDomainObject, TSe
 export class BaseParentDataService<TDataType extends IBaseDomainObject, TSearchParams, TResourceDictionaryType>
 	extends BaseDataService<TDataType, TSearchParams> implements IBaseParentDataService<TDataType, TSearchParams, TResourceDictionaryType> {
 	constructor($http: ng.IHttpService, $q: ng.IQService, array: IArrayUtility, endpoint: string, mockData: TDataType[]
-		, protected resourceDictionaryBuilder: { (baseEndpoint: string): TResourceDictionaryType }
+		, public resourceDictionaryBuilder: { (baseEndpoint: string): TResourceDictionaryType }
 		, transform?: ITransformFunction<TDataType>
 		, useMock?: boolean
         , logRequests?: boolean) {

--- a/source/services/dataContracts/baseParentDataService/baseParentData.service.ts
+++ b/source/services/dataContracts/baseParentDataService/baseParentData.service.ts
@@ -13,36 +13,24 @@ export interface IBaseParentDataService<TDataType extends IBaseDomainObject, TSe
 
 export class BaseParentDataService<TDataType extends IBaseDomainObject, TSearchParams, TResourceDictionaryType>
 	extends BaseDataService<TDataType, TSearchParams> implements IBaseParentDataService<TDataType, TSearchParams, TResourceDictionaryType> {
-	private _childContracts: TResourceDictionaryType;
-
 	constructor($http: ng.IHttpService, $q: ng.IQService, array: IArrayUtility, endpoint: string, mockData: TDataType[]
-		, protected resourceDictionaryBuilder: { (): TResourceDictionaryType }
+		, protected resourceDictionaryBuilder: { (baseEndpoint: string): TResourceDictionaryType }
 		, transform?: ITransformFunction<TDataType>
 		, useMock?: boolean
         , logRequests?: boolean) {
 		super($http, $q, array, endpoint, mockData, transform, useMock, logRequests);
-		this._childContracts = this.resourceDictionaryBuilder();
 	}
 
 	childContracts(id?: number): TResourceDictionaryType {
 		if (_.isUndefined(id)) {
-			return <any>_.mapValues(this._childContracts, (dataService: any): IBaseDataService<TDataType, TSearchParams> => {
-				let contract: any = dataService.clone();
-				contract.endpoint = this.endpoint + contract.endpoint;
-				return contract;
-			});
+			return this.resourceDictionaryBuilder(this.endpoint);
 		} else {
-			let dictionary: {[index: string]: any} = this._childContracts;
+			let dictionary: {[index: string]: any} = this.resourceDictionaryBuilder(this.endpoint + '/' + id);
 			return <any>_.mapValues(dictionary, (dataService: IBaseDataServiceView<TDataType, TSearchParams>): IBaseSingletonDataService<TDataType> | IBaseDataService<TDataType, TSearchParams> => {
-				let contract: any = dataService;
-
-				if (_.isFunction(contract.AsSingleton)) {
-					contract = contract.AsSingleton(id);
-				} else {
-					contract = contract.clone();
+				if (_.isFunction(dataService.AsSingleton)) {
+					return dataService.AsSingleton(id);
 				}
-				contract.endpoint = this.endpoint + '/' + id + contract.endpoint;
-				return contract;
+				return dataService;
 			});
 		}
 	}

--- a/source/services/dataContracts/baseParentDataService/baseParentData.service.ts
+++ b/source/services/dataContracts/baseParentDataService/baseParentData.service.ts
@@ -9,7 +9,7 @@ import { IBaseSingletonDataService } from '../baseSingletonDataService/baseSingl
 export interface IBaseParentDataService<TDataType extends IBaseDomainObject, TSearchParams, TResourceDictionaryType>
 	extends IBaseDataService<TDataType, TSearchParams>{
 	childContracts(id?: number): TResourceDictionaryType;
-	baseChildContracts: TResourceDictionaryType;
+	baseChildContracts(): TResourceDictionaryType;
 }
 
 export class BaseParentDataService<TDataType extends IBaseDomainObject, TSearchParams, TResourceDictionaryType>
@@ -48,7 +48,7 @@ export class BaseParentDataService<TDataType extends IBaseDomainObject, TSearchP
 		}
 	}
 
-	get baseChildContracts(): TResourceDictionaryType {
+	baseChildContracts(): TResourceDictionaryType {
 		return this._childContracts;
 	}
 }

--- a/source/services/dataContracts/baseParentDataService/baseParentData.service.ts
+++ b/source/services/dataContracts/baseParentDataService/baseParentData.service.ts
@@ -17,7 +17,7 @@ export class BaseParentDataService<TDataType extends IBaseDomainObject, TSearchP
 	private _childContracts: TResourceDictionaryType;
 
 	constructor($http: ng.IHttpService, $q: ng.IQService, array: IArrayUtility, endpoint: string, mockData: TDataType[]
-		, private resourceDictionaryBuilder: { (): TResourceDictionaryType }
+		, protected resourceDictionaryBuilder: { (): TResourceDictionaryType }
 		, transform?: ITransformFunction<TDataType>
 		, useMock?: boolean
         , logRequests?: boolean) {

--- a/source/services/dataContracts/baseResourceBuilder/baseResourceBuilder.service.ts
+++ b/source/services/dataContracts/baseResourceBuilder/baseResourceBuilder.service.ts
@@ -6,7 +6,7 @@ import { IArrayUtility, serviceName as arrayServiceName, moduleName as arrayModu
 
 import { IContractLibrary, ContractLibrary, ILibraryServices } from './contractLibrary';
 import { IBaseDataService, BaseDataService, IBaseDomainObject, ITransformFunction } from '../baseDataService/baseData.service';
-import { IBaseDataServiceView, IBaseParentDataServiceView } from '../baseDataService/baseDataServiceView';
+import { IBaseDataServiceView, IBaseParentDataServiceView, BaseDataServiceView, BaseParentDataServiceView } from '../baseDataService/baseDataServiceView';
 import { IBaseParentDataService, BaseParentDataService } from '../baseParentDataService/baseParentData.service';
 import { IBaseSingletonDataService, BaseSingletonDataService } from '../baseSingletonDataService/baseSingletonData.service';
 import { IBaseParentSingletonDataService, BaseParentSingletonDataService } from '../baseParentSingletonDataService/baseParentSingletonData.service';
@@ -14,17 +14,12 @@ import { IBaseParentSingletonDataService, BaseParentSingletonDataService } from 
 export var moduleName: string = 'rl.utilities.services.baseResourceBuilder';
 export var serviceName: string = 'baseResourceBuilder';
 
-export interface IBaseResourceParams<TDataType extends IBaseDomainObject> {
+export interface IBaseOptions<TDataType> {
 	/**
 	* Url to hit with getList and create
 	* - extended with /id for getDetail, update, and delete
 	*/
 	endpoint?: string;
-
-	/**
-	* Example data set to be used for testing and prototyping instead of hitting the endpoint
-	*/
-	mockData?: TDataType[];
 
 	/**
 	* Flag for specifying if the data service should use the mock data or hit the actual endpoint
@@ -41,6 +36,13 @@ export interface IBaseResourceParams<TDataType extends IBaseDomainObject> {
 	* Processes data coming back from the server
 	*/
 	transform?: ITransformFunction<TDataType>;
+}
+
+export interface IBaseResourceParams<TDataType extends IBaseDomainObject> extends IBaseOptions<TDataType> {
+	/**
+	* Example data set to be used for testing and prototyping instead of hitting the endpoint
+	*/
+	mockData?: TDataType[];
 }
 
 export interface IParentResourceParams<TDataType extends IBaseDomainObject, TResourceDictionaryType> extends IBaseResourceParams<TDataType> {
@@ -50,32 +52,11 @@ export interface IParentResourceParams<TDataType extends IBaseDomainObject, TRes
 	resourceDictionaryBuilder?: { (): TResourceDictionaryType };
 }
 
-export interface ISingletonResourceParams<TDataType> {
-	/**
-	* Url to hit with get and update
-	*/
-	endpoint?: string;
-
+export interface ISingletonResourceParams<TDataType> extends IBaseOptions<TDataType> {
 	/**
 	* Example object to be used for testing and prototyping instead of hitting the endpoint
 	*/
 	mockData?: TDataType;
-
-	/**
-	* Flag for specifying if the data service should use the mock data or hit the actual endpoint
-	* defaults to true if endpoint is not defined
-	*/
-	useMock?: boolean;
-
-	/**
-	* Flag for specifying if the data service should log all requests against the contract
-	*/
-	logRequests?: boolean;
-
-	/**
-	* Processes data coming back from the server
-	*/
-	transform?: ITransformFunction<TDataType>;
 }
 
 export interface IParentSingletonResourceParams<TDataType, TResourceDictionaryType> extends ISingletonResourceParams<TDataType> {
@@ -162,29 +143,22 @@ export class BaseResourceBuilder implements IBaseResourceBuilder {
 	}
 
 	createResource<TDataType extends IBaseDomainObject, TSearchParams>(options: IBaseResourceParams<TDataType>): IBaseDataService<TDataType, TSearchParams> {
-		options.useMock = options.endpoint == null ? true : options.useMock;
+		options = this.useMockIfNoEndpoint(options);
 		let dataService: IBaseDataService<TDataType, TSearchParams> = new BaseDataService(this.$http, this.$q, this.array, options.endpoint, options.mockData, options.transform, options.useMock, options.logRequests);
 		(<any>dataService).clone = (endpoint: string): IBaseDataService<TDataType, TSearchParams> => { return this.cloneResource(dataService, endpoint); };
 		return dataService;
 	}
 
 	createResourceView<TDataType extends IBaseDomainObject, TSearchParams>(options: IBaseResourceParams<TDataType>): IBaseDataServiceView<TDataType, TSearchParams> {
-		let dataServiceView: IBaseDataServiceView<TDataType, TSearchParams> = <any>this.createResource(options);
+		options = this.useMockIfNoEndpoint(options);
+		let dataServiceView: IBaseDataServiceView<TDataType, TSearchParams> = new BaseDataServiceView(this.$http, this.$q, this.array, options.endpoint, options.mockData, options.transform, options.useMock, options.logRequests);
 		(<any>dataServiceView).clone = (endpoint: string): IBaseDataServiceView<TDataType, TSearchParams> => { return <any>this.cloneResource(dataServiceView, endpoint); };
-		dataServiceView.AsSingleton = function(parentId: number): IBaseSingletonDataService<TDataType> {
-			return {
-				get(): angular.IPromise<TDataType> { return dataServiceView.getDetail(parentId); },
-				update(domainObject: TDataType): angular.IPromise<void> { return dataServiceView.update(domainObject); },
-				useMock: dataServiceView.useMock,
-				logRequests: dataServiceView.logRequests,
-			};
-		}
 		return dataServiceView;
 	}
 
 	createParentResource<TDataType extends IBaseDomainObject, TSearchParams, TResourceDictionaryType>
 		(options: IParentResourceParams<TDataType, TResourceDictionaryType>): IBaseParentDataService<TDataType, TSearchParams, TResourceDictionaryType> {
-		options.useMock = options.endpoint == null ? true : options.useMock;
+		options = this.useMockIfNoEndpoint(options);
 		let parentDataService: IBaseParentDataService<TDataType, TSearchParams, TResourceDictionaryType>
 			= new BaseParentDataService(this.$http, this.$q, this.array, options.endpoint, options.mockData, options.resourceDictionaryBuilder, options.transform, options.useMock, options.logRequests);
 		(<any>parentDataService).clone = (endpoint: string): IBaseParentDataService<TDataType, TSearchParams, TResourceDictionaryType> => { return this.cloneParentResource(parentDataService, endpoint); };
@@ -193,23 +167,15 @@ export class BaseResourceBuilder implements IBaseResourceBuilder {
 
 	createParentResourceView<TDataType extends IBaseDomainObject, TSearchParams, TResourceDictionaryType>
 		(options: IParentResourceParams<TDataType, TResourceDictionaryType>): IBaseParentDataServiceView<TDataType, TSearchParams, TResourceDictionaryType> {
-		let dataServiceView: IBaseParentDataServiceView<TDataType, TSearchParams, TResourceDictionaryType> = <any>this.createParentResource(options);
+		options = this.useMockIfNoEndpoint(options);
+		let dataServiceView: IBaseParentDataServiceView<TDataType, TSearchParams, TResourceDictionaryType>
+			= new BaseParentDataServiceView(this.$http, this.$q, this.array, options.endpoint, options.mockData, options.resourceDictionaryBuilder, options.transform, options.useMock, options.logRequests);
 		(<any>dataServiceView).clone = (endpoint: string): IBaseParentDataServiceView<TDataType, TSearchParams, TResourceDictionaryType> => { return <any>this.cloneParentResource(dataServiceView, endpoint); };
-		dataServiceView.AsSingleton = function(parentId: number): IBaseParentSingletonDataService<TDataType, TResourceDictionaryType> {
-			return <any>{
-				get(): angular.IPromise<TDataType> { return dataServiceView.getDetail(parentId); },
-				update(domainObject: TDataType): angular.IPromise<void> { return dataServiceView.update(domainObject); },
-				useMock: dataServiceView.useMock,
-				logRequests: dataServiceView.logRequests,
-				childContracts(): TResourceDictionaryType { return dataServiceView.childContracts(parentId); },
-				clone: (<any>dataServiceView).clone,
-			};
-		}
 		return dataServiceView;
 	}
 
 	createSingletonResource<TDataType>(options: ISingletonResourceParams<TDataType>): IBaseSingletonDataService<TDataType> {
-		options.useMock = options.endpoint == null ? true : options.useMock;
+		options = this.useMockIfNoEndpoint(options);
 		let dataService: IBaseSingletonDataService<TDataType> = new BaseSingletonDataService(this.$http, this.$q, options.endpoint, options.mockData, options.transform, options.useMock, options.logRequests);
 		(<any>dataService).clone = (endpoint: string): IBaseSingletonDataService<TDataType> => { return this.cloneSingletonResource(dataService, endpoint); };
 		return dataService;
@@ -217,7 +183,7 @@ export class BaseResourceBuilder implements IBaseResourceBuilder {
 
 	createParentSingletonResource<TDataType, TResourceDictionaryType>
 		(options: IParentSingletonResourceParams<TDataType, TResourceDictionaryType>): IBaseParentSingletonDataService<TDataType, TResourceDictionaryType> {
-		options.useMock = options.endpoint == null ? true : options.useMock;
+		options = this.useMockIfNoEndpoint(options);
 		let parentDataService: IBaseParentSingletonDataService<TDataType, TResourceDictionaryType>
 			= new BaseParentSingletonDataService(this.$http, this.$q, options.endpoint, options.mockData, options.resourceDictionaryBuilder, options.transform, options.useMock, options.logRequests);
 		(<any>parentDataService).clone = (endpoint: string): IBaseParentSingletonDataService<TDataType, TResourceDictionaryType> => { return this.cloneParentSingletonResource(parentDataService, endpoint); };
@@ -257,6 +223,11 @@ export class BaseResourceBuilder implements IBaseResourceBuilder {
 		let clone: IBaseParentSingletonDataService<TDataType, TResourceDictionaryType> = <any>this.cloneSingletonResource(resource, endpoint);
 		clone.childContracts = (): TResourceDictionaryType => { return resource.childContracts(); };
 		return clone;
+	}
+
+	private useMockIfNoEndpoint<TDataType>(options: IBaseOptions<TDataType>): IBaseOptions<TDataType> {
+		options.useMock = options.endpoint == null ? true : options.useMock;
+		return options;
 	}
 }
 

--- a/source/services/dataContracts/baseResourceBuilder/baseResourceBuilder.service.ts
+++ b/source/services/dataContracts/baseResourceBuilder/baseResourceBuilder.service.ts
@@ -174,16 +174,6 @@ s			= new BaseParentDataServiceView(this.$http, this.$q, this.array, options.end
 			logRequests: castedResource.logRequests,
 		};
 	}
-
-	private cloneSingletonResource<TDataType>(resource: IBaseSingletonDataService<TDataType>): IBaseSingletonDataService<TDataType> {
-		let castedResource: BaseSingletonDataService<TDataType> = <BaseSingletonDataService<TDataType>>resource;
-		return {
-			get(): angular.IPromise<TDataType> { return castedResource.get(endpoint); },
-			update(domainObject: TDataType): angular.IPromise<void> { return castedResource.update(domainObject, endpoint); },
-			useMock: castedResource.useMock,
-			logRequests: castedResource.logRequests,
-		};
-	}
 	}
 
 	private useMockIfNoEndpoint<TDataType>(options: IBaseOptions<TDataType>): IBaseOptions<TDataType> {

--- a/source/services/dataContracts/baseResourceBuilder/baseResourceBuilder.service.ts
+++ b/source/services/dataContracts/baseResourceBuilder/baseResourceBuilder.service.ts
@@ -104,19 +104,6 @@ export interface IBaseResourceBuilder {
 		(options: IParentResourceParams<TDataType, TResourceDictionaryType>): IBaseParentDataService<TDataType, void, TResourceDictionaryType>;
 
 	/**
-	* Create a view of a parent resource with sub-resources that can be used as a base resource or
-	* as a singleton if a parent is selected
-	*/
-	createParentResourceView<TDataType extends IBaseDomainObject, TSearchParams, TResourceDictionaryType>
-		(options: IParentResourceParams<TDataType, TResourceDictionaryType>): IBaseParentDataService<TDataType, TSearchParams, TResourceDictionaryType>;
-	/**
-	* Create a view of a parent resource with sub-resources that can be used as a base resource or
-	* as a singleton if a parent is selected
-	*/
-	createParentResourceView<TDataType extends IBaseDomainObject, TResourceDictionaryType>
-		(options: IParentResourceParams<TDataType, TResourceDictionaryType>): IBaseParentDataService<TDataType, void, TResourceDictionaryType>;
-
-	/**
 	* Deprecated - Create a singleton resource with get and update
 	*/
 	createSingletonResource<TDataType>(options: ISingletonResourceParams<TDataType>): IBaseSingletonDataService<TDataType>;
@@ -159,35 +146,20 @@ export class BaseResourceBuilder implements IBaseResourceBuilder {
 	createParentResource<TDataType extends IBaseDomainObject, TSearchParams, TResourceDictionaryType>
 		(options: IParentResourceParams<TDataType, TResourceDictionaryType>): IBaseParentDataService<TDataType, TSearchParams, TResourceDictionaryType> {
 		options = this.useMockIfNoEndpoint(options);
-		let parentDataService: IBaseParentDataService<TDataType, TSearchParams, TResourceDictionaryType>
-			= new BaseParentDataService(this.$http, this.$q, this.array, options.endpoint, options.mockData, options.resourceDictionaryBuilder, options.transform, options.useMock, options.logRequests);
-		(<any>parentDataService).clone = (endpoint: string): IBaseParentDataService<TDataType, TSearchParams, TResourceDictionaryType> => { return this.cloneParentResource(parentDataService, endpoint); };
-		return parentDataService;
-	}
-
-	createParentResourceView<TDataType extends IBaseDomainObject, TSearchParams, TResourceDictionaryType>
-		(options: IParentResourceParams<TDataType, TResourceDictionaryType>): IBaseParentDataServiceView<TDataType, TSearchParams, TResourceDictionaryType> {
-		options = this.useMockIfNoEndpoint(options);
+		return new BaseParentDataService(this.$http, this.$q, this.array, options.endpoint, options.mockData, options.resourceDictionaryBuilder, options.transform, options.useMock, options.logRequests);
 		let dataServiceView: IBaseParentDataServiceView<TDataType, TSearchParams, TResourceDictionaryType>
-			= new BaseParentDataServiceView(this.$http, this.$q, this.array, options.endpoint, options.mockData, options.resourceDictionaryBuilder, options.transform, options.useMock, options.logRequests);
-		(<any>dataServiceView).clone = (endpoint: string): IBaseParentDataServiceView<TDataType, TSearchParams, TResourceDictionaryType> => { return <any>this.cloneParentResource(dataServiceView, endpoint); };
-		return dataServiceView;
+s			= new BaseParentDataServiceView(this.$http, this.$q, this.array, options.endpoint, options.mockData, options.resourceDictionaryBuilder, options.transform, options.useMock, options.logRequests);
 	}
 
 	createSingletonResource<TDataType>(options: ISingletonResourceParams<TDataType>): IBaseSingletonDataService<TDataType> {
 		options = this.useMockIfNoEndpoint(options);
-		let dataService: IBaseSingletonDataService<TDataType> = new BaseSingletonDataService(this.$http, this.$q, options.endpoint, options.mockData, options.transform, options.useMock, options.logRequests);
-		(<any>dataService).clone = (endpoint: string): IBaseSingletonDataService<TDataType> => { return this.cloneSingletonResource(dataService, endpoint); };
-		return dataService;
+		return new BaseSingletonDataService(this.$http, this.$q, options.endpoint, options.mockData, options.transform, options.useMock, options.logRequests);
 	}
 
 	createParentSingletonResource<TDataType, TResourceDictionaryType>
 		(options: IParentSingletonResourceParams<TDataType, TResourceDictionaryType>): IBaseParentSingletonDataService<TDataType, TResourceDictionaryType> {
 		options = this.useMockIfNoEndpoint(options);
-		let parentDataService: IBaseParentSingletonDataService<TDataType, TResourceDictionaryType>
-			= new BaseParentSingletonDataService(this.$http, this.$q, options.endpoint, options.mockData, options.resourceDictionaryBuilder, options.transform, options.useMock, options.logRequests);
-		(<any>parentDataService).clone = (endpoint: string): IBaseParentSingletonDataService<TDataType, TResourceDictionaryType> => { return this.cloneParentSingletonResource(parentDataService, endpoint); };
-		return parentDataService;
+		return new BaseParentSingletonDataService(this.$http, this.$q, options.endpoint, options.mockData, options.resourceDictionaryBuilder, options.transform, options.useMock, options.logRequests);
 	}
 
 	private cloneResource<TDataType extends IBaseDomainObject, TSearchParams>(resource: IBaseDataService<TDataType, TSearchParams>, endpoint: string): IBaseDataService<TDataType, TSearchParams> {
@@ -203,13 +175,7 @@ export class BaseResourceBuilder implements IBaseResourceBuilder {
 		};
 	}
 
-	private cloneParentResource<TDataType extends IBaseDomainObject, TSearchParams, TResourceDictionaryType>(resource: IBaseParentDataService<TDataType, TSearchParams, TResourceDictionaryType>, endpoint: string): IBaseParentDataService<TDataType, TSearchParams, TResourceDictionaryType> {
-		let clone: IBaseParentDataService<TDataType, TSearchParams, TResourceDictionaryType> = <any>this.cloneResource(resource, endpoint);
-		clone.childContracts = (id: number): TResourceDictionaryType => { return resource.childContracts(id); };
-		return clone;
-	}
-
-	private cloneSingletonResource<TDataType>(resource: IBaseSingletonDataService<TDataType>, endpoint: string): IBaseSingletonDataService<TDataType> {
+	private cloneSingletonResource<TDataType>(resource: IBaseSingletonDataService<TDataType>): IBaseSingletonDataService<TDataType> {
 		let castedResource: BaseSingletonDataService<TDataType> = <BaseSingletonDataService<TDataType>>resource;
 		return {
 			get(): angular.IPromise<TDataType> { return castedResource.get(endpoint); },
@@ -218,17 +184,11 @@ export class BaseResourceBuilder implements IBaseResourceBuilder {
 			logRequests: castedResource.logRequests,
 		};
 	}
-
-	private cloneParentSingletonResource<TDataType, TResourceDictionaryType>(resource: IBaseParentSingletonDataService<TDataType, TResourceDictionaryType>, endpoint: string): IBaseParentSingletonDataService<TDataType, TResourceDictionaryType> {
-		let clone: IBaseParentSingletonDataService<TDataType, TResourceDictionaryType> = <any>this.cloneSingletonResource(resource, endpoint);
-		clone.childContracts = (): TResourceDictionaryType => { return resource.childContracts(); };
-		return clone;
 	}
 
 	private useMockIfNoEndpoint<TDataType>(options: IBaseOptions<TDataType>): IBaseOptions<TDataType> {
 		options.useMock = options.endpoint == null ? true : options.useMock;
 		return options;
-	}
 }
 
 angular.module(moduleName, [arrayModuleName])

--- a/source/services/dataContracts/baseResourceBuilder/baseResourceBuilder.service.ts
+++ b/source/services/dataContracts/baseResourceBuilder/baseResourceBuilder.service.ts
@@ -131,15 +131,12 @@ export class BaseResourceBuilder implements IBaseResourceBuilder {
 
 	createResource<TDataType extends IBaseDomainObject, TSearchParams>(options: IBaseResourceParams<TDataType>): IBaseDataService<TDataType, TSearchParams> {
 		options = this.useMockIfNoEndpoint(options);
-		let dataService: IBaseDataService<TDataType, TSearchParams> = new BaseDataService(this.$http, this.$q, this.array, options.endpoint, options.mockData, options.transform, options.useMock, options.logRequests);
-		(<any>dataService).clone = (endpoint: string): IBaseDataService<TDataType, TSearchParams> => { return this.cloneResource(dataService, endpoint); };
-		return dataService;
+		return new BaseDataService(this.$http, this.$q, this.array, options.endpoint, options.mockData, options.transform, options.useMock, options.logRequests);
 	}
 
 	createResourceView<TDataType extends IBaseDomainObject, TSearchParams>(options: IBaseResourceParams<TDataType>): IBaseDataServiceView<TDataType, TSearchParams> {
 		options = this.useMockIfNoEndpoint(options);
 		let dataServiceView: IBaseDataServiceView<TDataType, TSearchParams> = new BaseDataServiceView(this.$http, this.$q, this.array, options.endpoint, options.mockData, options.transform, options.useMock, options.logRequests);
-		(<any>dataServiceView).clone = (endpoint: string): IBaseDataServiceView<TDataType, TSearchParams> => { return <any>this.cloneResource(dataServiceView, endpoint); };
 		return dataServiceView;
 	}
 
@@ -160,19 +157,6 @@ s			= new BaseParentDataServiceView(this.$http, this.$q, this.array, options.end
 		(options: IParentSingletonResourceParams<TDataType, TResourceDictionaryType>): IBaseParentSingletonDataService<TDataType, TResourceDictionaryType> {
 		options = this.useMockIfNoEndpoint(options);
 		return new BaseParentSingletonDataService(this.$http, this.$q, options.endpoint, options.mockData, options.resourceDictionaryBuilder, options.transform, options.useMock, options.logRequests);
-	}
-
-	private cloneResource<TDataType extends IBaseDomainObject, TSearchParams>(resource: IBaseDataService<TDataType, TSearchParams>, endpoint: string): IBaseDataService<TDataType, TSearchParams> {
-		let castedResource: BaseDataService<TDataType, TSearchParams> = <BaseDataService<TDataType, TSearchParams>>resource;
-		return {
-			getList(params?: TSearchParams): angular.IPromise<TDataType[]> { return castedResource.getList(params, endpoint); },
-			getDetail(id: number): angular.IPromise<TDataType> { return castedResource.getDetail(id, endpoint); },
-			create(domainObject: TDataType): angular.IPromise<TDataType> { return castedResource.create(domainObject, endpoint); },
-			update(domainObject: TDataType): angular.IPromise<void> { return castedResource.update(domainObject, endpoint); },
-			delete(domainObject: TDataType): angular.IPromise<void> { return castedResource.delete(domainObject, endpoint); },
-			useMock: castedResource.useMock,
-			logRequests: castedResource.logRequests,
-		};
 	}
 	}
 

--- a/source/services/dataContracts/baseResourceBuilder/baseResourceBuilder.service.ts
+++ b/source/services/dataContracts/baseResourceBuilder/baseResourceBuilder.service.ts
@@ -104,6 +104,19 @@ export interface IBaseResourceBuilder {
 		(options: IParentResourceParams<TDataType, TResourceDictionaryType>): IBaseParentDataService<TDataType, void, TResourceDictionaryType>;
 
 	/**
+	* Create a view of a parent resource with sub-resources that can be used as a base resource or
+	* as a singleton if a parent is selected
+	*/
+	createParentResourceView<TDataType extends IBaseDomainObject, TSearchParams, TResourceDictionaryType>
+		(options: IParentResourceParams<TDataType, TResourceDictionaryType>): IBaseParentDataService<TDataType, TSearchParams, TResourceDictionaryType>;
+	/**
+	* Create a view of a parent resource with sub-resources that can be used as a base resource or
+	* as a singleton if a parent is selected
+	*/
+	createParentResourceView<TDataType extends IBaseDomainObject, TResourceDictionaryType>
+		(options: IParentResourceParams<TDataType, TResourceDictionaryType>): IBaseParentDataService<TDataType, void, TResourceDictionaryType>;
+
+	/**
 	* Deprecated - Create a singleton resource with get and update
 	*/
 	createSingletonResource<TDataType>(options: ISingletonResourceParams<TDataType>): IBaseSingletonDataService<TDataType>;
@@ -136,16 +149,19 @@ export class BaseResourceBuilder implements IBaseResourceBuilder {
 
 	createResourceView<TDataType extends IBaseDomainObject, TSearchParams>(options: IBaseResourceParams<TDataType>): IBaseDataServiceView<TDataType, TSearchParams> {
 		options = this.useMockIfNoEndpoint(options);
-		let dataServiceView: IBaseDataServiceView<TDataType, TSearchParams> = new BaseDataServiceView(this.$http, this.$q, this.array, options.endpoint, options.mockData, options.transform, options.useMock, options.logRequests);
-		return dataServiceView;
+		return new BaseDataServiceView(this.$http, this.$q, this.array, options.endpoint, options.mockData, options.transform, options.useMock, options.logRequests);
 	}
 
 	createParentResource<TDataType extends IBaseDomainObject, TSearchParams, TResourceDictionaryType>
 		(options: IParentResourceParams<TDataType, TResourceDictionaryType>): IBaseParentDataService<TDataType, TSearchParams, TResourceDictionaryType> {
 		options = this.useMockIfNoEndpoint(options);
 		return new BaseParentDataService(this.$http, this.$q, this.array, options.endpoint, options.mockData, options.resourceDictionaryBuilder, options.transform, options.useMock, options.logRequests);
-		let dataServiceView: IBaseParentDataServiceView<TDataType, TSearchParams, TResourceDictionaryType>
-s			= new BaseParentDataServiceView(this.$http, this.$q, this.array, options.endpoint, options.mockData, options.resourceDictionaryBuilder, options.transform, options.useMock, options.logRequests);
+	}
+
+	createParentResourceView<TDataType extends IBaseDomainObject, TSearchParams, TResourceDictionaryType>
+		(options: IParentResourceParams<TDataType, TResourceDictionaryType>): IBaseParentDataServiceView<TDataType, TSearchParams, TResourceDictionaryType> {
+		options = this.useMockIfNoEndpoint(options);
+		return new BaseParentDataServiceView(this.$http, this.$q, this.array, options.endpoint, options.mockData, options.resourceDictionaryBuilder, options.transform, options.useMock, options.logRequests);
 	}
 
 	createSingletonResource<TDataType>(options: ISingletonResourceParams<TDataType>): IBaseSingletonDataService<TDataType> {
@@ -158,11 +174,11 @@ s			= new BaseParentDataServiceView(this.$http, this.$q, this.array, options.end
 		options = this.useMockIfNoEndpoint(options);
 		return new BaseParentSingletonDataService(this.$http, this.$q, options.endpoint, options.mockData, options.resourceDictionaryBuilder, options.transform, options.useMock, options.logRequests);
 	}
-	}
 
 	private useMockIfNoEndpoint<TDataType>(options: IBaseOptions<TDataType>): IBaseOptions<TDataType> {
 		options.useMock = options.endpoint == null ? true : options.useMock;
 		return options;
+	}
 }
 
 angular.module(moduleName, [arrayModuleName])

--- a/source/services/dataContracts/baseResourceBuilder/contractLibrary.ts
+++ b/source/services/dataContracts/baseResourceBuilder/contractLibrary.ts
@@ -15,6 +15,8 @@ export interface IContractLibrary {
 	mockGet(resource: any, data: any): Sinon.SinonSpy;
 	mockGetList(resource: any, data: any): Sinon.SinonSpy;
 	mockGetDetail(resource: any, data: any): Sinon.SinonSpy;
+
+	mockChild(parent: any, mockCallback: { (children: any): void }): void;
 }
 
 export interface ILibraryServices {
@@ -46,6 +48,15 @@ export class ContractLibrary implements IContractLibrary {
 
 	mockGetDetail(resource: any, data: any): Sinon.SinonSpy {
 		return this.baseMockGet(resource, 'getDetail', data);
+	}
+
+	mockChild(parent: any, mockCallback: { (children: any): void }): void {
+		let getChildren: {(id: number): any} = parent.childContracts.bind(parent);
+		parent.childContracts = (id: number): any => {
+			let children: any = getChildren(id);
+			mockCallback(children);
+			return children;
+		}
 	}
 
 	private baseMockGet(resource: any, actionName: string, data: any): Sinon.SinonSpy {

--- a/source/services/dataContracts/baseResourceBuilder/contractLibrary.ts
+++ b/source/services/dataContracts/baseResourceBuilder/contractLibrary.ts
@@ -6,17 +6,17 @@ import * as ng from 'angular';
 import * as _ from 'lodash';
 
 import { IBaseResourceBuilder, BaseResourceBuilder } from './baseResourceBuilder.service';
+import { IBaseDataServiceMock, IBaseParentDataServiceMock, IBaseSingletonDataServiceMock } from './dataServiceMocks';
 
 export interface IContractLibrary {
 	// extend with custom interface specifying child resources
 
 	flush(): void;
 
-	mockGet(resource: any, data: any): Sinon.SinonSpy;
-	mockGetList(resource: any, data: any): Sinon.SinonSpy;
-	mockGetDetail(resource: any, data: any): Sinon.SinonSpy;
-
 	mockChild(parent: any, mockCallback: { (children: any): void }): void;
+	createMock(resource?: any): IBaseDataServiceMock<any, any>;
+	createMockParent(resource?: any): IBaseParentDataServiceMock<any, any, any>;
+	createMockSingleton(resource?: any): IBaseSingletonDataServiceMock<any>;
 }
 
 export interface ILibraryServices {
@@ -28,7 +28,7 @@ export class ContractLibrary implements IContractLibrary {
 	private $q: ng.IQService;
 	private $rootScope: ng.IRootScopeService;
 
-	constructor(builder: IBaseResourceBuilder) {
+	constructor(private builder: IBaseResourceBuilder) {
 		let services: ILibraryServices = (<BaseResourceBuilder>builder).getLibraryServices();
 		this.$q = services.$q;
 		this.$rootScope = services.$rootScope;
@@ -36,18 +36,6 @@ export class ContractLibrary implements IContractLibrary {
 
 	flush(): void {
 		this.$rootScope.$digest();
-	}
-
-	mockGet(resource: any, data: any): Sinon.SinonSpy {
-		return this.baseMockGet(resource, 'get', data);
-	}
-
-	mockGetList(resource: any, data: any): Sinon.SinonSpy {
-		return this.baseMockGet(resource, 'getList', data);
-	}
-
-	mockGetDetail(resource: any, data: any): Sinon.SinonSpy {
-		return this.baseMockGet(resource, 'getDetail', data);
 	}
 
 	mockChild(parent: any, mockCallback: { (children: any): void }): void {
@@ -59,12 +47,48 @@ export class ContractLibrary implements IContractLibrary {
 		}
 	}
 
+	createMock(resource?: any): IBaseDataServiceMock<any, any> {
+		let dataService: IBaseDataServiceMock<any, any> = <any>this.builder.createResource<any, any>({});
+		dataService.mockGetList = (data: any[]): Sinon.SinonSpy => { return this.baseMockGet(dataService, 'getList', data); };
+		dataService.mockGetDetail = (data: any): Sinon.SinonSpy => { return this.baseMockGet(dataService, 'get', data); };
+		this.updateResource(dataService, resource);
+		return dataService;
+	}
+
+	createMockParent(resource?: any): IBaseParentDataServiceMock<any, any, any> {
+		let getChildren: any = resource != null ? resource.resourceDictionaryBuilder : (): any => { return {}; };
+		let dataService: IBaseParentDataServiceMock<any, any, any> = <any>this.builder.createParentResource<any, any, any>({
+			resourceDictionaryBuilder: getChildren,
+		});
+		dataService.mockGetList = (data: any[]): Sinon.SinonSpy => { return this.baseMockGet(dataService, 'getList', data); };
+		dataService.mockGetDetail = (data: any): Sinon.SinonSpy => { return this.baseMockGet(dataService, 'get', data); };
+		dataService.mockChild = (mockCallback: { (children: any): void }): void => { return this.mockChild(dataService, mockCallback); };
+		this.updateResource(dataService, resource);
+		return dataService;
+	}
+
+	createMockSingleton(resource?: any): IBaseSingletonDataServiceMock<any> {
+		let dataService: IBaseSingletonDataServiceMock<any> = <any>this.builder.createSingletonResource({});
+		dataService.mockGet = (data: any): Sinon.SinonSpy => { return this.baseMockGet(dataService, 'get', data); };
+		this.updateResource(dataService, resource);
+		return dataService;
+	}
+
+	private updateResource(dataService: any, resource?: any): void {
+		if (resource != null) {
+			_.extend(resource, dataService);
+		}
+	}
+
 	private baseMockGet(resource: any, actionName: string, data: any): Sinon.SinonSpy {
-		let sinonInstance: Sinon.SinonStatic = sinon || <any>{ spy: (func: any): any => { return func; } };
-		let func: Sinon.SinonSpy = sinonInstance.spy((): any => {
+		let func: Sinon.SinonSpy = this.sinon.spy((): any => {
 			return this.$q.when(data);
 		});
 		resource[actionName] = func;
 		return func;
+	}
+
+	private get sinon(): Sinon.SinonStatic {
+		return sinon || <any>{ spy: (func: any): any => { return func; } };
 	}
 }

--- a/source/services/dataContracts/baseResourceBuilder/contractLibrary.ts
+++ b/source/services/dataContracts/baseResourceBuilder/contractLibrary.ts
@@ -13,6 +13,10 @@ export interface IContractLibrary {
 
 	flush(): void;
 
+	mockGet(resource: any, data: any): Sinon.SinonSpy;
+	mockGetList(resource: any, data: any): Sinon.SinonSpy;
+	mockGetDetail(resource: any, data: any): Sinon.SinonSpy;
+
 	mockChild(parent: any, mockCallback: { (children: any): void }): void;
 	createMock(resource?: any): IBaseDataServiceMock<any, any>;
 	createMockParent(resource?: any): IBaseParentDataServiceMock<any, any, any>;
@@ -36,6 +40,17 @@ export class ContractLibrary implements IContractLibrary {
 
 	flush(): void {
 		this.$rootScope.$digest();
+	}
+	mockGet(resource: any, data: any): Sinon.SinonSpy {
+		return this.baseMockGet(resource, 'get', data);
+	}
+
+	mockGetList(resource: any, data: any): Sinon.SinonSpy {
+		return this.baseMockGet(resource, 'getList', data);
+	}
+
+	mockGetDetail(resource: any, data: any): Sinon.SinonSpy {
+		return this.baseMockGet(resource, 'getDetail', data);
 	}
 
 	mockChild(parent: any, mockCallback: { (children: any): void }): void {

--- a/source/services/dataContracts/baseResourceBuilder/dataServiceMocks.ts
+++ b/source/services/dataContracts/baseResourceBuilder/dataServiceMocks.ts
@@ -1,0 +1,22 @@
+/// <reference path='../../../../typings/sinon/sinon.d.ts' />
+
+'use strict';
+
+import { IBaseDataService, IBaseDomainObject } from '../baseDataService/baseData.service';
+import { IBaseParentDataService } from '../baseParentDataService/baseParentData.service';
+import { IBaseSingletonDataService } from '../baseSingletonDataService/baseSingletonData.service';
+
+export interface IBaseDataServiceMock<TDataType extends IBaseDomainObject, TSearchParams> extends IBaseDataService<TDataType, TSearchParams> {
+	mockGetList(data: any[]): Sinon.SinonSpy;
+	mockGetDetail(data: any): Sinon.SinonSpy;
+}
+
+export interface IBaseParentDataServiceMock<TDataType extends IBaseDomainObject, TSearchParams, TResourceDictionaryType> extends IBaseParentDataService<TDataType, TSearchParams, TResourceDictionaryType> {
+	mockGetList(data: any[]): Sinon.SinonSpy;
+	mockGetDetail(data: any): Sinon.SinonSpy;
+	mockChild(mockCallback: { (children: any): void }): void;
+}
+
+export interface IBaseSingletonDataServiceMock<TDataType> extends IBaseSingletonDataService<TDataType> {
+	mockGet(data: any): Sinon.SinonSpy;
+}

--- a/source/services/dataContracts/baseResourceBuilder/dataServiceMocks.ts
+++ b/source/services/dataContracts/baseResourceBuilder/dataServiceMocks.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../typings/sinon/sinon.d.ts' />
+// /// <reference path='../../../../typings/sinon/sinon.d.ts' />
 
 'use strict';
 

--- a/source/services/dataContracts/baseSingletonDataService/baseSingletonData.service.ts
+++ b/source/services/dataContracts/baseSingletonDataService/baseSingletonData.service.ts
@@ -29,12 +29,12 @@ export class BaseSingletonDataService<TDataType> implements IBaseSingletonDataSe
         return this._endpoint;
     }
 
-    get(endpoint?: string): angular.IPromise<TDataType> {
+    get(): angular.IPromise<TDataType> {
         let promise: angular.IPromise<TDataType>;
         if (this.useMock) {
             promise = this.$q.when(this.mockData);
         } else {
-            promise = this.$http.get(this.getEndpointOrDefault(endpoint))
+            promise = this.$http.get(this.endpoint)
                 .then((response: angular.IHttpPromiseCallbackArg<TDataType>): TDataType => {
                 return response.data;
             });
@@ -50,13 +50,13 @@ export class BaseSingletonDataService<TDataType> implements IBaseSingletonDataSe
         });
     }
 
-    update(domainObject: TDataType, endpoint?: string): angular.IPromise<void> {
+    update(domainObject: TDataType): angular.IPromise<void> {
         let promise: angular.IPromise<void>;
         if (this.useMock) {
             this.mockData = <TDataType>_.assign(this.mockData, domainObject);
             promise = this.$q.when();
         } else {
-            promise = this.$http.put<void>(this.getEndpointOrDefault(endpoint), domainObject).then((): void => { return null; });
+            promise = this.$http.put<void>(this.endpoint, domainObject).then((): void => { return null; });
         }
         return promise.then((): void => {
             if (this.logRequests) {
@@ -70,10 +70,6 @@ export class BaseSingletonDataService<TDataType> implements IBaseSingletonDataSe
         let endpointString = this.endpoint == null ? 'unspecified' : this.endpoint;
         console.log(mockString + requestName + ' for endpoint ' + endpointString + ':');
         console.log(data);
-    }
-
-    private getEndpointOrDefault(endpoint?: string): string {
-        return endpoint != null ? endpoint : this.endpoint;
     }
 }
 

--- a/source/services/dataContracts/dataContracts.module.ts
+++ b/source/services/dataContracts/dataContracts.module.ts
@@ -10,7 +10,7 @@ export var moduleName: string = 'rl.utilities.services.dataContracts';
 
 export * from './baseResourceBuilder/contractLibrary';
 export { IBaseDataService, IBaseDataServiceFactory, IBaseDomainObject, BaseDataService, factoryName as baseDataServiceFactoryName } from './baseDataService/baseData.service';
-export { IBaseDataServiceView } from './baseDataService/baseDataServiceView';
+export { IBaseDataServiceView, IBaseParentDataServiceView } from './baseDataService/baseDataServiceView';
 export * from './baseParentDataService/baseParentData.service';
 export { IBaseSingletonDataService, IBaseSingletonDataServiceFactory, BaseSingletonDataService, factoryName as baseSingletonDataServiceFactoryName } from './baseSingletonDataService/baseSingletonData.service';
 export * from './baseParentSingletonDataService/baseParentSingletonData.service';

--- a/source/services/dataContracts/dataContracts.module.ts
+++ b/source/services/dataContracts/dataContracts.module.ts
@@ -10,7 +10,7 @@ export var moduleName: string = 'rl.utilities.services.dataContracts';
 
 export * from './baseResourceBuilder/contractLibrary';
 export { IBaseDataService, IBaseDataServiceFactory, IBaseDomainObject, BaseDataService, factoryName as baseDataServiceFactoryName } from './baseDataService/baseData.service';
-export { IBaseDataServiceView, IBaseParentDataServiceView } from './baseDataService/baseDataServiceView';
+export { IBaseDataServiceView } from './baseDataService/baseDataServiceView';
 export * from './baseParentDataService/baseParentData.service';
 export { IBaseSingletonDataService, IBaseSingletonDataServiceFactory, BaseSingletonDataService, factoryName as baseSingletonDataServiceFactoryName } from './baseSingletonDataService/baseSingletonData.service';
 export * from './baseParentSingletonDataService/baseParentSingletonData.service';

--- a/source/services/dataContracts/dataContracts.module.ts
+++ b/source/services/dataContracts/dataContracts.module.ts
@@ -6,6 +6,8 @@ import { moduleName as resourceBuilderModuleName } from './baseResourceBuilder/b
 import { moduleName as baseDataServiceModuleName } from './baseDataService/baseData.service';
 import { moduleName as baseSingletonDataServiceModuleName } from './baseSingletonDataService/baseSingletonData.service';
 
+import * as mocks from './baseResourceBuilder/dataServiceMocks';
+
 export var moduleName: string = 'rl.utilities.services.dataContracts';
 
 export * from './baseResourceBuilder/contractLibrary';
@@ -15,6 +17,7 @@ export * from './baseParentDataService/baseParentData.service';
 export { IBaseSingletonDataService, IBaseSingletonDataServiceFactory, BaseSingletonDataService, factoryName as baseSingletonDataServiceFactoryName } from './baseSingletonDataService/baseSingletonData.service';
 export * from './baseParentSingletonDataService/baseParentSingletonData.service';
 export { IBaseResourceBuilder, serviceName as builderServiceName } from './baseResourceBuilder/baseResourceBuilder.service';
+export { mocks };
 
 angular.module(moduleName, [
 	baseDataServiceModuleName,


### PR DESCRIPTION
Reverted change to make the child contracts static for mocking. Instead we'll provide a mockChild function for changing childContracts() to return a mock instead of the actual resource. Also provided tools for creating mock reasources. 
