### PR TITLE
Changed transform to an object with fromServer and toServer transform…

### DIFF
--- a/source/services/dataContracts/baseDataService/baseData.service.ts
+++ b/source/services/dataContracts/baseDataService/baseData.service.ts
@@ -4,16 +4,13 @@ import * as angular from 'angular';
 import * as _ from 'lodash';
 
 import { IArrayUtility, serviceName as arrayServiceName, moduleName as arrayModuleName } from '../../array/array.service';
+import { IBaseDataServiceBehavior, BaseDataServiceBehavior, ITransform } from '../baseDataServiceBehavior';
 
 export var moduleName: string = 'rl.utilities.services.baseDataService';
 export var factoryName: string = 'baseDataService';
 
 export interface IBaseDomainObject {
     id: number;
-}
-
-export interface ITransformFunction<TDataType> {
-	(rawData: any): TDataType;
 }
 
 export interface IBaseDataService<TDataType extends IBaseDomainObject, TSearchParams> {
@@ -28,136 +25,98 @@ export interface IBaseDataService<TDataType extends IBaseDomainObject, TSearchPa
 }
 
 export class BaseDataService<TDataType extends IBaseDomainObject, TSearchParams> implements IBaseDataService<TDataType, TSearchParams> {
-    constructor(protected $http: angular.IHttpService
-            , protected $q: angular.IQService
+    private behavior: IBaseDataServiceBehavior<TDataType>;
+
+    constructor($http: angular.IHttpService
+            , $q: angular.IQService
             , protected array: IArrayUtility
             , public endpoint: string
             , protected mockData: TDataType[]
-            , protected transform: ITransformFunction<TDataType>
+            , transform: ITransform<TDataType>
             , public useMock: boolean
-            , public logRequests: boolean) { }
+            , public logRequests: boolean) {
+        this.behavior = new BaseDataServiceBehavior($http, $q, transform);
+    }
 
     private getItemEndpoint(id: number): string {
         return this.endpoint + '/' + id.toString();
     }
 
     getList(params: TSearchParams): angular.IPromise<TDataType[]> {
-        let promise: angular.IPromise<TDataType[]>;
-        if (this.useMock) {
-            promise = this.$q.when(this.mockData);
-        } else {
-            promise = this.$http.get(this.endpoint, { params: params })
-                .then((response: angular.IHttpPromiseCallbackArg<TDataType[]>): TDataType[] => {
-                return response.data;
-            });
-        }
-        return promise.then((data: TDataType[]): TDataType[] => {
-            if (this.transform != null) {
-                data = _.map(data, this.transform);
-            }
-            if (this.logRequests) {
-                this.log('getList', data);
-            }
-            return data;
-        })
+        return this.behavior.getList({
+            params: params,
+            endpoint: this.endpoint,
+            getMockData(): TDataType[] { return this.mockData },
+            useMock: this.useMock,
+            logRequests: this.logRequests,
+        });
     }
 
     getDetail(id: number): angular.IPromise<TDataType> {
-        let promise: angular.IPromise<TDataType>;
-        if (this.useMock) {
-            promise = this.$q.when(_.find(this.mockData, (item: TDataType): boolean => {
-                return item.id === id;
-            }));
-        } else {
-            promise = this.$http.get(this.getItemEndpoint(id))
-                .then((response: angular.IHttpPromiseCallbackArg<TDataType>): TDataType => {
-                return response.data;
-            });
-        }
-        return promise.then((data: TDataType): TDataType => {
-            if (this.transform != null) {
-                data = this.transform(data);
-            }
-            if (this.logRequests) {
-                this.log('getDetail', data);
-            }
-            return data;
+        return this.behavior.getItem({
+            endpoint: this.getItemEndpoint(id),
+            getMockData: (): TDataType => {
+                return _.find(this.mockData, (item: TDataType): boolean => {
+                    return item.id === id;
+                });
+            },
+            useMock: this.useMock,
+            logRequests: this.logRequests,
         });
     }
 
     create(domainObject: TDataType): angular.IPromise<TDataType> {
-        let promise: angular.IPromise<TDataType>;
-        if (this.useMock) {
-            let nextId: number = _.max(this.mockData, 'id').id + 1;
-            domainObject.id = nextId;
-            this.mockData.push(domainObject);
-            promise = this.$q.when(domainObject);
-        } else {
-            promise = this.$http.post(this.endpoint, JSON.stringify(domainObject))
-                .then((result: angular.IHttpPromiseCallbackArg<TDataType>): TDataType => {
-                return result.data;
-            });
-        }
-        return promise.then((data: TDataType): TDataType => {
-            if (this.logRequests) {
-                this.log('create', data);
-            }
-            return data;
+        return this.behavior.create({
+            domainObject: domainObject,
+            endpoint: this.endpoint,
+            addMockData: (data: TDataType): void => {
+                let nextId: number = _.max(this.mockData, 'id').id + 1;
+                domainObject.id = nextId;
+                this.mockData.push(domainObject);
+            },
+            useMock: this.useMock,
+            logRequests: this.logRequests,
         });
     }
 
     update(domainObject: TDataType): angular.IPromise<TDataType> {
-        let promise: angular.IPromise<TDataType>;
-        if (this.useMock) {
-            let oldObject: TDataType = _.find(this.mockData, _.find(this.mockData, (item: TDataType): boolean => {
-                return item.id === domainObject.id;
-            }));
-            oldObject = <TDataType>_.assign(oldObject, domainObject);
-            promise = this.$q.when(oldObject);
-        } else {
-            promise = this.$http.put<void>(this.getItemEndpoint(domainObject.id), domainObject);
-        }
-        return promise.then((data: TDataType): TDataType => {
-            if (this.logRequests) {
-                this.log('update', domainObject);
-            }
-            return data;
+        return this.behavior.update({
+            domainObject: domainObject,
+            endpoint: this.endpoint,
+            updateMockData: (data: TDataType): void => {
+                let oldObject: TDataType = _.find(this.mockData, (item: TDataType): boolean => {
+                    return item.id === data.id;
+                });
+                oldObject = <TDataType>_.assign(oldObject, data);
+            },
+            useMock: this.useMock,
+            logRequests: this.logRequests,
         });
     }
 
     delete(domainObject: TDataType): angular.IPromise<void> {
-        let promise: angular.IPromise<void>;
-        if (this.useMock) {
-            this.array.remove(this.mockData, domainObject);
-            promise = this.$q.when();
-        } else {
-            promise = this.$http.delete<void>(this.getItemEndpoint(domainObject.id)).then((): void => { return null; });
-        }
-        return promise.then((): void => {
-            if (this.logRequests) {
-                this.log('update', domainObject);
-            }
+        return this.behavior.delete({
+            domainObject: domainObject,
+            endpoint: this.endpoint,
+            removeMockData: (data: TDataType): void => {
+                this.array.remove(this.mockData, domainObject);
+            },
+            useMock: this.useMock,
+            logRequests: this.logRequests,
         });
-    }
-
-    private log(requestName: string, data: any): void {
-        let mockString = this.useMock ? 'Mocked ' : '';
-        let endpointString = this.endpoint == null ? 'unspecified' : this.endpoint;
-        console.log(mockString + requestName + ' for endpoint ' + endpointString + ':');
-        console.log(data);
     }
 }
 
 export interface IBaseDataServiceFactory {
     getInstance<TDataType extends IBaseDomainObject, TSearchParams>(endpoint: string, mockData?: TDataType[]
-        , transform?: ITransformFunction<TDataType>, useMock?: boolean): IBaseDataService<TDataType, TSearchParams>;
+        , transform?: ITransform<TDataType>, useMock?: boolean): IBaseDataService<TDataType, TSearchParams>;
 }
 
 baseDataServiceFactory.$inject = ['$http', '$q', arrayServiceName];
 export function baseDataServiceFactory($http: angular.IHttpService, $q: angular.IQService, array: IArrayUtility): IBaseDataServiceFactory {
     return {
         getInstance<TDataType extends IBaseDomainObject, TSearchParams>(endpoint: string, mockData?: TDataType[]
-            , transform?: ITransformFunction<TDataType>, useMock?: boolean, logRequests?: boolean): IBaseDataService<TDataType, TSearchParams> {
+            , transform?: ITransform<TDataType>, useMock?: boolean, logRequests?: boolean): IBaseDataService<TDataType, TSearchParams> {
             return new BaseDataService<TDataType, TSearchParams>($http, $q, array, endpoint, mockData, transform, useMock, logRequests);
         },
     };

--- a/source/services/dataContracts/baseDataService/baseData.service.ts
+++ b/source/services/dataContracts/baseDataService/baseData.service.ts
@@ -46,7 +46,7 @@ export class BaseDataService<TDataType extends IBaseDomainObject, TSearchParams>
         return this.behavior.getList({
             params: params,
             endpoint: this.endpoint,
-            getMockData(): TDataType[] { return this.mockData },
+            getMockData: (): TDataType[] => { return this.mockData },
             useMock: this.useMock,
             logRequests: this.logRequests,
         });

--- a/source/services/dataContracts/baseDataService/baseDataServiceView.ts
+++ b/source/services/dataContracts/baseDataService/baseDataServiceView.ts
@@ -2,7 +2,8 @@
 
 import { IArrayUtility, serviceName as arrayServiceName, moduleName as arrayModuleName } from '../../array/array.service';
 
-import { IBaseDataService, BaseDataService, IBaseDomainObject, ITransformFunction } from './baseData.service';
+import { ITransform } from '../baseDataServiceBehavior';
+import { IBaseDataService, BaseDataService, IBaseDomainObject } from './baseData.service';
 import { IBaseParentDataService, BaseParentDataService } from '../baseParentDataService/baseParentData.service';
 import { IBaseSingletonDataService, BaseSingletonDataService } from '../baseSingletonDataService/baseSingletonData.service';
 import { IBaseParentSingletonDataService, BaseParentSingletonDataService } from '../baseParentSingletonDataService/baseParentSingletonData.service';
@@ -19,12 +20,12 @@ export interface IBaseParentDataServiceView<TDataType extends IBaseDomainObject,
 export class BaseDataServiceView<TDataType extends IBaseDomainObject, TSearchParams>
 	extends BaseDataService<TDataType, TSearchParams>
 	implements IBaseDataServiceView<TDataType, TSearchParams> {
-    constructor($http: angular.IHttpService
-            , $q: angular.IQService
+    constructor(private $http: angular.IHttpService
+            , private $q: angular.IQService
             , array: IArrayUtility
             , _endpoint: string
             , mockData: TDataType[]
-            , transform: ITransformFunction<TDataType>
+            , private transform: ITransform<TDataType>
             , useMock: boolean
             , logRequests: boolean) {
 		super($http, $q, array, _endpoint, mockData, transform, useMock, logRequests);
@@ -41,13 +42,13 @@ export class BaseDataServiceView<TDataType extends IBaseDomainObject, TSearchPar
 export class BaseParentDataServiceView<TDataType extends IBaseDomainObject, TSearchParams, TResourceDictionaryType>
 	extends BaseParentDataService<TDataType, TSearchParams, TResourceDictionaryType>
 	implements IBaseParentDataServiceView<TDataType, TSearchParams, TResourceDictionaryType> {
-    constructor($http: angular.IHttpService
-            , $q: angular.IQService
+    constructor(private $http: angular.IHttpService
+            , private $q: angular.IQService
             , array: IArrayUtility
             , _endpoint: string
             , mockData: TDataType[]
 			, resourceDictionaryBuilder: {(): TResourceDictionaryType}
-            , transform: ITransformFunction<TDataType>
+            , private transform: ITransform<TDataType>
             , useMock: boolean
             , logRequests: boolean) {
 		super($http, $q, array, _endpoint, mockData, resourceDictionaryBuilder, transform, useMock, logRequests);

--- a/source/services/dataContracts/baseDataServiceBehavior.ts
+++ b/source/services/dataContracts/baseDataServiceBehavior.ts
@@ -1,0 +1,166 @@
+'use strict';
+
+import * as angular from 'angular';
+import * as _ from 'lodash';
+
+export interface ITransform<TDataType> {
+    fromServer(rawData: any): TDataType;
+    toServer(data: TDataType): any,
+}
+
+export interface IRequestOptions {
+    endpoint: string;
+    useMock: boolean;
+    logRequests: boolean;
+}
+
+export interface IGetListOptions<TDataType> extends IRequestOptions {
+    params: any;
+    getMockData(): TDataType[];
+}
+
+export interface IGetItemOptions<TDataType> extends IRequestOptions {
+    getMockData(): TDataType;
+}
+
+export interface ICreateOptions<TDataType> extends IRequestOptions {
+    domainObject: TDataType;
+    addMockData(data: TDataType): void;
+}
+
+export interface IUpdateOptions<TDataType> extends IRequestOptions {
+    domainObject: TDataType;
+    updateMockData(data: TDataType): void;
+}
+
+export interface IDeleteOptions<TDataType> extends IRequestOptions {
+    domainObject: TDataType;
+    removeMockData(data: TDataType): void;
+}
+
+export interface IBaseDataServiceBehavior<TDataType> {
+	getList(options: IGetListOptions<TDataType>): angular.IPromise<TDataType[]>;
+    getItem(options: IGetItemOptions<TDataType>): angular.IPromise<TDataType>;
+    create(options: ICreateOptions<TDataType>): angular.IPromise<TDataType>;
+    update(options: IUpdateOptions<TDataType>): angular.IPromise<TDataType>;
+    delete(options: IDeleteOptions<TDataType>): angular.IPromise<void>;
+}
+
+export class BaseDataServiceBehavior<TDataType> implements IBaseDataServiceBehavior<TDataType> {
+    constructor(private $http: angular.IHttpService
+            , private $q: angular.IQService
+            , private transform: ITransform<TDataType>) { }
+
+    getList(options: IGetListOptions<TDataType>): angular.IPromise<TDataType[]> {
+        let promise: angular.IPromise<TDataType[]>;
+        if (options.useMock) {
+            promise = this.$q.when(options.getMockData());
+        } else {
+            promise = this.$http.get(options.endpoint, { params: options.params })
+                .then((response: angular.IHttpPromiseCallbackArg<TDataType[]>): TDataType[] => {
+                return response.data;
+            });
+        }
+        return promise.then((data: TDataType[]): TDataType[] => {
+            if (this.transform != null) {
+                data = _.map(data, this.transform.fromServer);
+            }
+            if (options.logRequests) {
+                this.log('getList', data, options.endpoint, options.useMock);
+            }
+            return data;
+        })
+    }
+
+    getItem(options: IGetItemOptions<TDataType>): angular.IPromise<TDataType> {
+        let promise: angular.IPromise<TDataType>;
+        if (options.useMock) {
+            promise = this.$q.when(options.getMockData());
+        } else {
+            promise = this.$http.get(options.endpoint)
+                .then((response: angular.IHttpPromiseCallbackArg<TDataType>): TDataType => {
+                return response.data;
+            });
+        }
+        return promise.then((data: TDataType): TDataType => {
+            data = this.transformFromServer(data);
+            if (options.logRequests) {
+                this.log('get', data, options.endpoint, options.useMock);
+            }
+            return data;
+        });
+    }
+
+    create(options: ICreateOptions<TDataType>): angular.IPromise<TDataType> {
+        let promise: angular.IPromise<TDataType>;
+        options.domainObject = this.transformToServer(options.domainObject);
+        if (options.useMock) {
+            options.addMockData(options.domainObject);
+            promise = this.$q.when(options.domainObject);
+        } else {
+            promise = this.$http.post(options.endpoint, JSON.stringify(options.domainObject))
+                .then((result: angular.IHttpPromiseCallbackArg<TDataType>): TDataType => {
+                return result.data;
+            });
+        }
+        return promise.then((data: TDataType): TDataType => {
+            data = this.transformFromServer(data);
+            if (options.logRequests) {
+                this.log('create', data, options.endpoint, options.useMock);
+            }
+            return data;
+        });
+    }
+
+    update(options: IUpdateOptions<TDataType>): angular.IPromise<TDataType> {
+        let promise: angular.IPromise<TDataType>;
+        options.domainObject = this.transformToServer(options.domainObject);
+        if (options.useMock) {
+            options.updateMockData(options.domainObject)
+            promise = this.$q.when(options.domainObject);
+        } else {
+            promise = this.$http.put(options.endpoint, options.domainObject);
+        }
+        return promise.then((data: TDataType): TDataType => {
+            data = this.transformFromServer(data);
+            if (options.logRequests) {
+                this.log('update', options.domainObject, options.endpoint, options.useMock);
+            }
+            return data;
+        });
+    }
+
+    delete(options: IDeleteOptions<TDataType>): angular.IPromise<void> {
+        let promise: angular.IPromise<void>;
+        if (options.useMock) {
+            options.removeMockData(options.domainObject);
+            promise = this.$q.when();
+        } else {
+            promise = this.$http.delete<void>(options.endpoint).then((): void => { return null; });
+        }
+        return promise.then((): void => {
+            if (options.logRequests) {
+                this.log('delete', options.domainObject, options.endpoint, options.useMock);
+            }
+        });
+    }
+
+    private log(requestName: string, data: any, endpoint: string, useMock: boolean): void {
+        let mockString = useMock ? 'Mocked ' : '';
+        let endpointString = endpoint == null ? 'unspecified' : endpoint;
+        console.log(mockString + requestName + ' for endpoint ' + endpointString + ':');
+        console.log(data);
+    }
+
+    private transformFromServer(rawData: any): TDataType {
+        return this.transform != null
+            ? this.transform.fromServer(rawData)
+            : rawData;
+    }
+
+    private transformToServer(data: TDataType): any {
+        return this.transform != null
+            ? this.transform.toServer(data)
+            : data;
+    }
+}

--- a/source/services/dataContracts/baseParentDataService/baseParentData.service.ts
+++ b/source/services/dataContracts/baseParentDataService/baseParentData.service.ts
@@ -3,7 +3,8 @@ import * as _ from 'lodash';
 
 import { IArrayUtility } from '../../array/array.service';
 
-import { IBaseDataService, BaseDataService, IBaseDomainObject, ITransformFunction } from '../baseDataService/baseData.service';
+import { ITransform } from '../baseDataServiceBehavior';
+import { IBaseDataService, BaseDataService, IBaseDomainObject } from '../baseDataService/baseData.service';
 import { IBaseDataServiceView } from '../baseDataService/baseDataServiceView';
 import { IBaseSingletonDataService } from '../baseSingletonDataService/baseSingletonData.service';
 
@@ -16,7 +17,7 @@ export class BaseParentDataService<TDataType extends IBaseDomainObject, TSearchP
 	extends BaseDataService<TDataType, TSearchParams> implements IBaseParentDataService<TDataType, TSearchParams, TResourceDictionaryType> {
 	constructor($http: ng.IHttpService, $q: ng.IQService, array: IArrayUtility, endpoint: string, mockData: TDataType[]
 		, public resourceDictionaryBuilder: { (baseEndpoint: string): TResourceDictionaryType }
-		, transform?: ITransformFunction<TDataType>
+		, transform?: ITransform<TDataType>
 		, useMock?: boolean
         , logRequests?: boolean) {
 		super($http, $q, array, endpoint, mockData, transform, useMock, logRequests);

--- a/source/services/dataContracts/baseParentSingletonDataService/baseParentSingletonData.service.ts
+++ b/source/services/dataContracts/baseParentSingletonDataService/baseParentSingletonData.service.ts
@@ -1,6 +1,6 @@
 import * as ng from 'angular';
 
-import { ITransformFunction } from '../baseDataService/baseData.service';
+import { ITransform } from '../baseDataServiceBehavior';
 import { IBaseSingletonDataService, BaseSingletonDataService } from '../baseSingletonDataService/baseSingletonData.service';
 
 export interface IBaseParentSingletonDataService<TDataType, TResourceDictionaryType>
@@ -12,7 +12,7 @@ export class BaseParentSingletonDataService<TDataType, TResourceDictionaryType>
 	extends BaseSingletonDataService<TDataType> implements IBaseParentSingletonDataService<TDataType, TResourceDictionaryType> {
 	constructor($http: ng.IHttpService, $q: ng.IQService, endpoint: string, mockData: TDataType
 		, private resourceDictionaryBuilder: { (baseEndpoint: string): TResourceDictionaryType }
-		, transform?: ITransformFunction<TDataType>
+		, transform?: ITransform<TDataType>
 		, useMock?: boolean
 		, logRequests?: boolean) {
 		super($http, $q, endpoint, mockData, transform, useMock, logRequests);

--- a/source/services/dataContracts/baseResourceBuilder/baseResourceBuilder.service.ts
+++ b/source/services/dataContracts/baseResourceBuilder/baseResourceBuilder.service.ts
@@ -5,7 +5,8 @@ import * as angular from 'angular';
 import { IArrayUtility, serviceName as arrayServiceName, moduleName as arrayModuleName } from '../../array/array.service';
 
 import { IContractLibrary, ContractLibrary, ILibraryServices } from './contractLibrary';
-import { IBaseDataService, BaseDataService, IBaseDomainObject, ITransformFunction } from '../baseDataService/baseData.service';
+import { ITransform } from '../baseDataServiceBehavior';
+import { IBaseDataService, BaseDataService, IBaseDomainObject } from '../baseDataService/baseData.service';
 import { IBaseDataServiceView, IBaseParentDataServiceView, BaseDataServiceView, BaseParentDataServiceView } from '../baseDataService/baseDataServiceView';
 import { IBaseParentDataService, BaseParentDataService } from '../baseParentDataService/baseParentData.service';
 import { IBaseSingletonDataService, BaseSingletonDataService } from '../baseSingletonDataService/baseSingletonData.service';
@@ -35,7 +36,7 @@ export interface IBaseOptions<TDataType> {
 	/**
 	* Processes data coming back from the server
 	*/
-	transform?: ITransformFunction<TDataType>;
+	transform?: ITransform<TDataType>;
 }
 
 export interface IBaseResourceParams<TDataType extends IBaseDomainObject> extends IBaseOptions<TDataType> {

--- a/source/services/dataContracts/baseSingletonDataService/baseSingletonData.service.ts
+++ b/source/services/dataContracts/baseSingletonDataService/baseSingletonData.service.ts
@@ -32,7 +32,7 @@ export class BaseSingletonDataService<TDataType> implements IBaseSingletonDataSe
     get(): angular.IPromise<TDataType> {
         return this.behavior.getItem({
             endpoint: this.endpoint,
-            getMockData(): TDataType { return this.mockData; },
+            getMockData: (): TDataType => { return this.mockData; },
             useMock: this.useMock,
             logRequests: this.logRequests,
         });


### PR DESCRIPTION
… functions.

Created a behavior class to share code implementation between BaseDataService and BaseSingletonDataService. The base and base singleton data services should only need to handle tweaking the endpoints and how to get and update the mock data correctly

This should've been two separate commits, but I was already halfway through moving the logic to a shared behavior before I thought about committing the transform changes.

**Breaking change**
