### PR TITLE
Make the id nullable. We don't need to require consumers to specify a…

### DIFF
--- a/source/services/dataContracts/baseDataService/baseData.service.ts
+++ b/source/services/dataContracts/baseDataService/baseData.service.ts
@@ -10,7 +10,7 @@ export var moduleName: string = 'rl.utilities.services.baseDataService';
 export var factoryName: string = 'baseDataService';
 
 export interface IBaseDomainObject {
-    id: number;
+    id?: number;
 }
 
 export interface IBaseDataService<TDataType extends IBaseDomainObject, TSearchParams> {


### PR DESCRIPTION
…n id if they're creating a new object of this type. If an id is missing, the worse that can happen is that the id will be null and they'll get an error when it tries to hit an endpoint with a null id. (endpoint will be `/resource/null`)
