### PR TITLE
Parent singleton

### DIFF
--- a/source/services/dataContracts/baseDataService/baseDataServiceView.ts
+++ b/source/services/dataContracts/baseDataService/baseDataServiceView.ts
@@ -58,6 +58,6 @@ export class BaseParentDataServiceView<TDataType extends IBaseDomainObject, TSea
 		let mockData: TDataType = _.find(this.mockData, (item: TDataType): boolean => {
 			return item.id === parentId;
 		});
-		return new BaseParentSingletonDataService<TDataType, TResourceDictionaryType>(this.$http, this.$q, this.endpoint, mockData, this.resourceDictionaryBuilder, this.transform, this.useMock, this.logRequests);
+		return new BaseParentSingletonDataService<TDataType, TResourceDictionaryType>(this.$http, this.$q, this.endpoint, mockData, this.resourceDictionaryBuilder, this.transform, this.useMock, this.logRequests, parentId);
 	}
 }

--- a/source/services/dataContracts/baseParentDataService/baseParentData.service.ts
+++ b/source/services/dataContracts/baseParentDataService/baseParentData.service.ts
@@ -16,7 +16,7 @@ export interface IBaseParentDataService<TDataType extends IBaseDomainObject, TSe
 export class BaseParentDataService<TDataType extends IBaseDomainObject, TSearchParams, TResourceDictionaryType>
 	extends BaseDataService<TDataType, TSearchParams> implements IBaseParentDataService<TDataType, TSearchParams, TResourceDictionaryType> {
 	constructor($http: ng.IHttpService, $q: ng.IQService, array: IArrayUtility, endpoint: string, mockData: TDataType[]
-		, public resourceDictionaryBuilder: { (baseEndpoint: string): TResourceDictionaryType }
+		, public resourceDictionaryBuilder: { (): TResourceDictionaryType }
 		, transform?: ITransform<TDataType>
 		, useMock?: boolean
         , logRequests?: boolean) {
@@ -25,13 +25,13 @@ export class BaseParentDataService<TDataType extends IBaseDomainObject, TSearchP
 
 	childContracts(id?: number): TResourceDictionaryType {
 		if (_.isUndefined(id)) {
-			let dictionary: TResourceDictionaryType = this.resourceDictionaryBuilder(this.endpoint);
+			let dictionary: TResourceDictionaryType = this.resourceDictionaryBuilder();
 			_.each(dictionary, (dataService: any): void => {
 				dataService.endpoint = this.endpoint + dataService.endpoint;
 			});
 			return dictionary;
 		} else {
-			let dictionary: {[index: string]: any} = this.resourceDictionaryBuilder(this.endpoint + '/' + id);
+			let dictionary: {[index: string]: any} = this.resourceDictionaryBuilder();
 			return <any>_.mapValues(dictionary, (dataService: IBaseDataServiceView<TDataType, TSearchParams>): IBaseSingletonDataService<TDataType> | IBaseDataService<TDataType, TSearchParams> => {
 				let contract: any;
 				if (_.isFunction(dataService.AsSingleton)) {

--- a/source/services/dataContracts/baseParentSingletonDataService/baseParentSingletonData.service.ts
+++ b/source/services/dataContracts/baseParentSingletonDataService/baseParentSingletonData.service.ts
@@ -2,6 +2,8 @@ import * as ng from 'angular';
 
 import { ITransform } from '../baseDataServiceBehavior';
 import { IBaseSingletonDataService, BaseSingletonDataService } from '../baseSingletonDataService/baseSingletonData.service';
+import { IBaseDataService, BaseDataService, IBaseDomainObject } from '../baseDataService/baseData.service';
+import { IBaseDataServiceView } from '../baseDataService/baseDataServiceView';
 
 export interface IBaseParentSingletonDataService<TDataType, TResourceDictionaryType>
 	extends IBaseSingletonDataService<TDataType>{
@@ -20,6 +22,18 @@ export class BaseParentSingletonDataService<TDataType, TResourceDictionaryType>
 	}
 
 	childContracts(): TResourceDictionaryType {
-		return this.resourceDictionaryBuilder(this.endpoint);
+		let dictionary: {[index: string]: any} = this.resourceDictionaryBuilder();
+		return <any>_.mapValues(dictionary, (dataService: IBaseDataServiceView<TDataType, any>): IBaseSingletonDataService<TDataType> | IBaseDataService<TDataType, any> => {
+			let contract: any;
+			if (_.isFunction(dataService.AsSingleton)) {
+				contract = dataService.AsSingleton(this.parentId);
+			} else {
+				contract = dataService;
+			}
+
+			contract.endpoint = this.endpoint + contract.endpoint;
+
+			return contract;
+		});
 	}
 }

--- a/source/services/dataContracts/baseParentSingletonDataService/baseParentSingletonData.service.ts
+++ b/source/services/dataContracts/baseParentSingletonDataService/baseParentSingletonData.service.ts
@@ -14,7 +14,8 @@ export class BaseParentSingletonDataService<TDataType, TResourceDictionaryType>
 		, private resourceDictionaryBuilder: { (): TResourceDictionaryType }
 		, transform?: ITransform<TDataType>
 		, useMock?: boolean
-		, logRequests?: boolean) {
+		, logRequests?: boolean
+		, private parentId?: number) {
 		super($http, $q, endpoint, mockData, transform, useMock, logRequests);
 	}
 

--- a/source/services/dataContracts/baseParentSingletonDataService/baseParentSingletonData.service.ts
+++ b/source/services/dataContracts/baseParentSingletonDataService/baseParentSingletonData.service.ts
@@ -11,7 +11,7 @@ export interface IBaseParentSingletonDataService<TDataType, TResourceDictionaryT
 export class BaseParentSingletonDataService<TDataType, TResourceDictionaryType>
 	extends BaseSingletonDataService<TDataType> implements IBaseParentSingletonDataService<TDataType, TResourceDictionaryType> {
 	constructor($http: ng.IHttpService, $q: ng.IQService, endpoint: string, mockData: TDataType
-		, private resourceDictionaryBuilder: { (baseEndpoint: string): TResourceDictionaryType }
+		, private resourceDictionaryBuilder: { (): TResourceDictionaryType }
 		, transform?: ITransform<TDataType>
 		, useMock?: boolean
 		, logRequests?: boolean) {

--- a/source/services/dataContracts/baseResourceBuilder/baseResourceBuilder.service.ts
+++ b/source/services/dataContracts/baseResourceBuilder/baseResourceBuilder.service.ts
@@ -64,7 +64,7 @@ export interface IParentSingletonResourceParams<TDataType, TResourceDictionaryTy
 	/**
 	* Function that builds a dictionary of child resources available through childContracts(id)
 	*/
-	resourceDictionaryBuilder?: { (baseEndpoint: string): TResourceDictionaryType };
+	resourceDictionaryBuilder?: { (): TResourceDictionaryType };
 }
 
 export interface IBaseResourceBuilder {


### PR DESCRIPTION
Updated childContracts to behave like the base parent data service with a slight difference. For the singleton, any resource view below it will be immediately transformed to a singleton, since it's a view of a singleton. We can just construct the endpoint as this.endpoint + contract.endpoint, since the parent singleton should already be scoped against the correct entity. (Example - /serviceEvent/9008/performedBy/child)

For parent resource views, this means that for a child that is defined as a view of the parent view, the consumer will be able to hit /serviceEvent/performedBy/child as a simple resource or /serviceEvent/9008/performedBy/child as a singleton.

The only minor issue here is that mock data will be handled incorrectly if a resource view is defined as a direct child of a singleton (not a view). Since the parent only gets an id upon transformation as a view, a parent that is defined as a singleton will implicitly expect all children to be singletons or collections.
