### PR TITLE
Map transform

### DIFF
--- a/source/services/dataContracts/baseDataService/baseData.service.ts
+++ b/source/services/dataContracts/baseDataService/baseData.service.ts
@@ -35,7 +35,8 @@ export class BaseDataService<TDataType extends IBaseDomainObject, TSearchParams>
             , transform: ITransform<TDataType>
             , public useMock: boolean
             , public logRequests: boolean) {
-        this.behavior = new BaseDataServiceBehavior($http, $q, transform);
+		// needs map property
+		this.behavior = new BaseDataServiceBehavior($http, $q, transform, null);
     }
 
     private getItemEndpoint(id: number): string {

--- a/source/services/dataContracts/baseDataService/baseData.service.ts
+++ b/source/services/dataContracts/baseDataService/baseData.service.ts
@@ -4,7 +4,7 @@ import * as angular from 'angular';
 import * as _ from 'lodash';
 
 import { IArrayUtility, serviceName as arrayServiceName, moduleName as arrayModuleName } from '../../array/array.service';
-import { IBaseDataServiceBehavior, BaseDataServiceBehavior, ITransform } from '../baseDataServiceBehavior';
+import { IBaseDataServiceBehavior, BaseDataServiceBehavior, IConverter, ITransform } from '../baseDataServiceBehavior';
 
 export var moduleName: string = 'rl.utilities.services.baseDataService';
 export var factoryName: string = 'baseDataService';
@@ -33,10 +33,10 @@ export class BaseDataService<TDataType extends IBaseDomainObject, TSearchParams>
             , public endpoint: string
             , protected mockData: TDataType[]
             , transform: ITransform<TDataType>
+			, map: { [index: string]: IConverter<TDataType> }
             , public useMock: boolean
             , public logRequests: boolean) {
-		// needs map property
-		this.behavior = new BaseDataServiceBehavior($http, $q, transform, null);
+		this.behavior = new BaseDataServiceBehavior($http, $q, transform, map);
     }
 
     private getItemEndpoint(id: number): string {
@@ -110,15 +110,15 @@ export class BaseDataService<TDataType extends IBaseDomainObject, TSearchParams>
 
 export interface IBaseDataServiceFactory {
     getInstance<TDataType extends IBaseDomainObject, TSearchParams>(endpoint: string, mockData?: TDataType[]
-        , transform?: ITransform<TDataType>, useMock?: boolean): IBaseDataService<TDataType, TSearchParams>;
+        , transform?: ITransform<TDataType>, map?: { [index: string]: IConverter<TDataType> }, useMock?: boolean): IBaseDataService<TDataType, TSearchParams>;
 }
 
 baseDataServiceFactory.$inject = ['$http', '$q', arrayServiceName];
 export function baseDataServiceFactory($http: angular.IHttpService, $q: angular.IQService, array: IArrayUtility): IBaseDataServiceFactory {
     return {
         getInstance<TDataType extends IBaseDomainObject, TSearchParams>(endpoint: string, mockData?: TDataType[]
-            , transform?: ITransform<TDataType>, useMock?: boolean, logRequests?: boolean): IBaseDataService<TDataType, TSearchParams> {
-            return new BaseDataService<TDataType, TSearchParams>($http, $q, array, endpoint, mockData, transform, useMock, logRequests);
+            , transform?: ITransform<TDataType>, map?: { [index: string]: IConverter<TDataType> }, useMock?: boolean, logRequests?: boolean): IBaseDataService<TDataType, TSearchParams> {
+            return new BaseDataService<TDataType, TSearchParams>($http, $q, array, endpoint, mockData, transform, map, useMock, logRequests);
         },
     };
 }

--- a/source/services/dataContracts/baseDataService/baseDataServiceView.ts
+++ b/source/services/dataContracts/baseDataService/baseDataServiceView.ts
@@ -2,7 +2,7 @@
 
 import { IArrayUtility, serviceName as arrayServiceName, moduleName as arrayModuleName } from '../../array/array.service';
 
-import { ITransform } from '../baseDataServiceBehavior';
+import { IConverter, ITransform } from '../baseDataServiceBehavior';
 import { IBaseDataService, BaseDataService, IBaseDomainObject } from './baseData.service';
 import { IBaseParentDataService, BaseParentDataService } from '../baseParentDataService/baseParentData.service';
 import { IBaseSingletonDataService, BaseSingletonDataService } from '../baseSingletonDataService/baseSingletonData.service';
@@ -26,16 +26,17 @@ export class BaseDataServiceView<TDataType extends IBaseDomainObject, TSearchPar
             , _endpoint: string
             , mockData: TDataType[]
             , private transform: ITransform<TDataType>
+			, private map: { [index: string]: IConverter<TDataType> }
             , useMock: boolean
             , logRequests: boolean) {
-		super($http, $q, array, _endpoint, mockData, transform, useMock, logRequests);
+		super($http, $q, array, _endpoint, mockData, transform, map, useMock, logRequests);
 	}
 
 	AsSingleton(parentId: number): IBaseSingletonDataService<TDataType> {
 		let mockData: TDataType = _.find(this.mockData, (item: TDataType): boolean => {
 			return item.id === parentId;
 		});
-		return new BaseSingletonDataService<TDataType>(this.$http, this.$q, this.endpoint, mockData, this.transform, this.useMock, this.logRequests);
+		return new BaseSingletonDataService<TDataType>(this.$http, this.$q, this.endpoint, mockData, this.transform, this.map, this.useMock, this.logRequests);
 	}
 }
 
@@ -49,15 +50,16 @@ export class BaseParentDataServiceView<TDataType extends IBaseDomainObject, TSea
             , mockData: TDataType[]
 			, resourceDictionaryBuilder: {(): TResourceDictionaryType}
             , private transform: ITransform<TDataType>
+			, private map: { [index: string]: IConverter<TDataType> }
             , useMock: boolean
             , logRequests: boolean) {
-		super($http, $q, array, _endpoint, mockData, resourceDictionaryBuilder, transform, useMock, logRequests);
+		super($http, $q, array, _endpoint, mockData, resourceDictionaryBuilder, transform, map, useMock, logRequests);
 	}
 
 	AsSingleton(parentId: number): IBaseParentSingletonDataService<TDataType, TResourceDictionaryType> {
 		let mockData: TDataType = _.find(this.mockData, (item: TDataType): boolean => {
 			return item.id === parentId;
 		});
-		return new BaseParentSingletonDataService<TDataType, TResourceDictionaryType>(this.$http, this.$q, this.endpoint, mockData, this.resourceDictionaryBuilder, this.transform, this.useMock, this.logRequests, parentId);
+		return new BaseParentSingletonDataService<TDataType, TResourceDictionaryType>(this.$http, this.$q, this.endpoint, mockData, this.resourceDictionaryBuilder, this.transform, this.map, this.useMock, this.logRequests, parentId);
 	}
 }

--- a/source/services/dataContracts/baseDataServiceBehavior.tests.ts
+++ b/source/services/dataContracts/baseDataServiceBehavior.tests.ts
@@ -20,6 +20,12 @@ interface ITestMock {
 	prop?: string;
 }
 
+interface ITestMock2 {
+	id?: number;
+	prop1?: number;
+	prop2?: number;
+}
+
 describe('base data service behavior', () => {
 	let dataServiceBehavior: IBaseDataServiceBehavior<ITestMock>;
 
@@ -278,6 +284,7 @@ describe('base data service behavior', () => {
 		let $rootScope: angular.IRootScopeService;
 		let dataSet: ITestMock[];
 		let transform: any;
+		let numberConverter: any;
 
 		beforeEach((): void => {
 			dataSet = [
@@ -297,6 +304,15 @@ describe('base data service behavior', () => {
                     return {
                         prop: data,
                     };
+                }),
+			};
+
+			numberConverter = {
+				fromServer: sinon.spy((rawData: number): number => {
+					return rawData + 1;
+                }),
+                toServer: sinon.spy((data: number): number => {
+                    return data - 1;
                 }),
 			};
 
@@ -356,6 +372,81 @@ describe('base data service behavior', () => {
 
             expect(updateSpy.firstCall.args[0].prop).to.equal('made some changes');
             sinon.assert.calledOnce(transform.toServer);
+
+			$rootScope.$digest();
+        });
+	});
+
+	describe('map', (): void => {
+		let $rootScope: angular.IRootScopeService;
+		let numberConverter: any;
+
+		beforeEach((): void => {
+			let services: any = angularFixture.inject('$rootScope', '$q', '$http');
+			$rootScope = services.$rootScope;
+
+			numberConverter = {
+				fromServer: sinon.spy((rawData: number): number => {
+					return rawData + 1;
+                }),
+                toServer: sinon.spy((data: number): number => {
+                    return data - 1;
+                }),
+			};
+
+			let map: any = {
+				prop1: numberConverter,
+			};
+
+			dataServiceBehavior = new BaseDataServiceBehavior<ITestMock>(services.$http, services.$q, null, map);
+		});
+
+		it('should use a an object map to transform properties from the server', (done: MochaDone): void => {
+			let item: ITestMock2 = {
+				prop1: 4,
+				prop2: 4,
+			};
+
+			dataServiceBehavior.getItem({
+                useMock: true,
+                getMockData(): ITestMock { return item; },
+                endpoint: null,
+                logRequests: false,
+            }).then((data: ITestMock2): void => {
+				expect(data.prop1).to.equal(5);
+				expect(data.prop2).to.equal(4);
+				sinon.assert.calledOnce(numberConverter.fromServer);
+				done();
+			});
+
+			$rootScope.$digest();
+		});
+
+        it('should use an object map to transform properties for sending back to the server', (done: MochaDone): void => {
+			let updatedItem: ITestMock2 = {
+				prop1: 5,
+				prop2: 4,
+			};
+
+			let updateSpy: Sinon.SinonSpy = sinon.spy();
+
+            dataServiceBehavior.update({
+                domainObject: updatedItem,
+                useMock: true,
+                updateMockData: updateSpy,
+                endpoint: null,
+                logRequests: false,
+            }).then((data: ITestMock2): void => {
+                expect(data.prop1).to.equal(4);
+                expect(data.prop2).to.equal(4);
+				sinon.assert.calledOnce(numberConverter.fromServer);
+				done();
+            });
+
+            sinon.assert.calledOnce(updateSpy);
+			let updateArg: any = updateSpy.firstCall.args[0];
+            expect(updateArg.prop1).to.equal(4);
+            expect(updateArg.prop2).to.equal(4);
 
 			$rootScope.$digest();
         });

--- a/source/services/dataContracts/baseDataServiceBehavior.tests.ts
+++ b/source/services/dataContracts/baseDataServiceBehavior.tests.ts
@@ -437,7 +437,7 @@ describe('base data service behavior', () => {
                 endpoint: null,
                 logRequests: false,
             }).then((data: ITestMock2): void => {
-                expect(data.prop1).to.equal(4);
+                expect(data.prop1).to.equal(5);
                 expect(data.prop2).to.equal(4);
 				sinon.assert.calledOnce(numberConverter.fromServer);
 				done();

--- a/source/services/dataContracts/baseDataServiceBehavior.tests.ts
+++ b/source/services/dataContracts/baseDataServiceBehavior.tests.ts
@@ -43,7 +43,7 @@ describe('base data service behavior', () => {
 			$httpBackend = services.$httpBackend;
 
 			testUrl = '/api/test';
-			dataServiceBehavior = new BaseDataServiceBehavior<ITestMock>(services.$http, services.$q, null);
+			dataServiceBehavior = new BaseDataServiceBehavior<ITestMock>(services.$http, services.$q, null, null);
 		});
 
 		afterEach((): void => {
@@ -173,7 +173,7 @@ describe('base data service behavior', () => {
             $rootScope = services.$rootScope;
             array = services[arrayService];
 
-			dataServiceBehavior = new BaseDataServiceBehavior<ITestMock>(services.$http, services.$q, null);
+			dataServiceBehavior = new BaseDataServiceBehavior<ITestMock>(services.$http, services.$q, null, null);
 		});
 
 		it('should get the mocked data set', (done: MochaDone): void => {
@@ -316,7 +316,7 @@ describe('base data service behavior', () => {
                 }),
 			};
 
-			dataServiceBehavior = new BaseDataServiceBehavior<ITestMock>(services.$http, services.$q, transform);
+			dataServiceBehavior = new BaseDataServiceBehavior<ITestMock>(services.$http, services.$q, transform, null);
 		});
 
 		it('should transform each entry in the list', (done: MochaDone): void => {

--- a/source/services/dataContracts/baseDataServiceBehavior.ts
+++ b/source/services/dataContracts/baseDataServiceBehavior.ts
@@ -162,7 +162,7 @@ export class BaseDataServiceBehavior<TDataType> implements IBaseDataServiceBehav
 		if (this.transform != null) {
 			return this.transform.fromServer(rawData);
 		} else if (this.map != null) {
-			return <any>_.map(rawData, (prop: any, key: string): any => {
+			return <any>_.mapValues(rawData, (prop: any, key: string): any => {
 				if (_.has(this.map, key)) {
 					return this.map[key].fromServer(prop);
 				}
@@ -177,7 +177,7 @@ export class BaseDataServiceBehavior<TDataType> implements IBaseDataServiceBehav
 		if (this.transform != null) {
 			return this.transform.toServer(data);
 		} else if (this.map != null) {
-			return <any>_.map(data, (prop: any, key: string): any => {
+			return <any>_.mapValues(data, (prop: any, key: string): any => {
 				if (_.has(this.map, key)) {
 					return this.map[key].toServer(prop);
 				}

--- a/source/services/dataContracts/baseParentDataService/baseParentData.service.ts
+++ b/source/services/dataContracts/baseParentDataService/baseParentData.service.ts
@@ -3,7 +3,7 @@ import * as _ from 'lodash';
 
 import { IArrayUtility } from '../../array/array.service';
 
-import { ITransform } from '../baseDataServiceBehavior';
+import { IConverter, ITransform } from '../baseDataServiceBehavior';
 import { IBaseDataService, BaseDataService, IBaseDomainObject } from '../baseDataService/baseData.service';
 import { IBaseDataServiceView } from '../baseDataService/baseDataServiceView';
 import { IBaseSingletonDataService } from '../baseSingletonDataService/baseSingletonData.service';
@@ -18,9 +18,10 @@ export class BaseParentDataService<TDataType extends IBaseDomainObject, TSearchP
 	constructor($http: ng.IHttpService, $q: ng.IQService, array: IArrayUtility, endpoint: string, mockData: TDataType[]
 		, public resourceDictionaryBuilder: { (): TResourceDictionaryType }
 		, transform?: ITransform<TDataType>
+		, map?: { [index: string]: IConverter<TDataType> }
 		, useMock?: boolean
         , logRequests?: boolean) {
-		super($http, $q, array, endpoint, mockData, transform, useMock, logRequests);
+		super($http, $q, array, endpoint, mockData, transform, map, useMock, logRequests);
 	}
 
 	childContracts(id?: number): TResourceDictionaryType {

--- a/source/services/dataContracts/baseParentSingletonDataService/baseParentSingletonData.service.ts
+++ b/source/services/dataContracts/baseParentSingletonDataService/baseParentSingletonData.service.ts
@@ -1,6 +1,6 @@
 import * as ng from 'angular';
 
-import { ITransform } from '../baseDataServiceBehavior';
+import { IConverter, ITransform } from '../baseDataServiceBehavior';
 import { IBaseSingletonDataService, BaseSingletonDataService } from '../baseSingletonDataService/baseSingletonData.service';
 import { IBaseDataService, BaseDataService, IBaseDomainObject } from '../baseDataService/baseData.service';
 import { IBaseDataServiceView } from '../baseDataService/baseDataServiceView';
@@ -15,10 +15,11 @@ export class BaseParentSingletonDataService<TDataType, TResourceDictionaryType>
 	constructor($http: ng.IHttpService, $q: ng.IQService, endpoint: string, mockData: TDataType
 		, private resourceDictionaryBuilder: { (): TResourceDictionaryType }
 		, transform?: ITransform<TDataType>
+		, map?: { [index: string]: IConverter<TDataType> }
 		, useMock?: boolean
 		, logRequests?: boolean
 		, private parentId?: number) {
-		super($http, $q, endpoint, mockData, transform, useMock, logRequests);
+		super($http, $q, endpoint, mockData, transform, map, useMock, logRequests);
 	}
 
 	childContracts(): TResourceDictionaryType {

--- a/source/services/dataContracts/baseResourceBuilder/baseResourceBuilder.service.ts
+++ b/source/services/dataContracts/baseResourceBuilder/baseResourceBuilder.service.ts
@@ -5,7 +5,7 @@ import * as angular from 'angular';
 import { IArrayUtility, serviceName as arrayServiceName, moduleName as arrayModuleName } from '../../array/array.service';
 
 import { IContractLibrary, ContractLibrary, ILibraryServices } from './contractLibrary';
-import { ITransform } from '../baseDataServiceBehavior';
+import { IConverter, ITransform } from '../baseDataServiceBehavior';
 import { IBaseDataService, BaseDataService, IBaseDomainObject } from '../baseDataService/baseData.service';
 import { IBaseDataServiceView, IBaseParentDataServiceView, BaseDataServiceView, BaseParentDataServiceView } from '../baseDataService/baseDataServiceView';
 import { IBaseParentDataService, BaseParentDataService } from '../baseParentDataService/baseParentData.service';
@@ -32,6 +32,11 @@ export interface IBaseOptions<TDataType> {
 	* Flag for specifying if the data service should log all requests against the contract
 	*/
 	logRequests?: boolean;
+
+	/**
+	* Mapping to specify how properties should be transformed to and from the server
+	*/
+	map?: { [index: string]: IConverter<TDataType> };
 
 	/**
 	* Processes data coming back from the server
@@ -145,35 +150,35 @@ export class BaseResourceBuilder implements IBaseResourceBuilder {
 
 	createResource<TDataType extends IBaseDomainObject, TSearchParams>(options: IBaseResourceParams<TDataType>): IBaseDataService<TDataType, TSearchParams> {
 		options = this.useMockIfNoEndpoint(options);
-		return new BaseDataService(this.$http, this.$q, this.array, options.endpoint, options.mockData, options.transform, options.useMock, options.logRequests);
+		return new BaseDataService(this.$http, this.$q, this.array, options.endpoint, options.mockData, options.transform, options.map, options.useMock, options.logRequests);
 	}
 
 	createResourceView<TDataType extends IBaseDomainObject, TSearchParams>(options: IBaseResourceParams<TDataType>): IBaseDataServiceView<TDataType, TSearchParams> {
 		options = this.useMockIfNoEndpoint(options);
-		return new BaseDataServiceView(this.$http, this.$q, this.array, options.endpoint, options.mockData, options.transform, options.useMock, options.logRequests);
+		return new BaseDataServiceView(this.$http, this.$q, this.array, options.endpoint, options.mockData, options.transform, options.map, options.useMock, options.logRequests);
 	}
 
 	createParentResource<TDataType extends IBaseDomainObject, TSearchParams, TResourceDictionaryType>
 		(options: IParentResourceParams<TDataType, TResourceDictionaryType>): IBaseParentDataService<TDataType, TSearchParams, TResourceDictionaryType> {
 		options = this.useMockIfNoEndpoint(options);
-		return new BaseParentDataService(this.$http, this.$q, this.array, options.endpoint, options.mockData, options.resourceDictionaryBuilder, options.transform, options.useMock, options.logRequests);
+		return new BaseParentDataService(this.$http, this.$q, this.array, options.endpoint, options.mockData, options.resourceDictionaryBuilder, options.transform, options.map, options.useMock, options.logRequests);
 	}
 
 	createParentResourceView<TDataType extends IBaseDomainObject, TSearchParams, TResourceDictionaryType>
 		(options: IParentResourceParams<TDataType, TResourceDictionaryType>): IBaseParentDataServiceView<TDataType, TSearchParams, TResourceDictionaryType> {
 		options = this.useMockIfNoEndpoint(options);
-		return new BaseParentDataServiceView(this.$http, this.$q, this.array, options.endpoint, options.mockData, options.resourceDictionaryBuilder, options.transform, options.useMock, options.logRequests);
+		return new BaseParentDataServiceView(this.$http, this.$q, this.array, options.endpoint, options.mockData, options.resourceDictionaryBuilder, options.transform, options.map, options.useMock, options.logRequests);
 	}
 
 	createSingletonResource<TDataType>(options: ISingletonResourceParams<TDataType>): IBaseSingletonDataService<TDataType> {
 		options = this.useMockIfNoEndpoint(options);
-		return new BaseSingletonDataService(this.$http, this.$q, options.endpoint, options.mockData, options.transform, options.useMock, options.logRequests);
+		return new BaseSingletonDataService(this.$http, this.$q, options.endpoint, options.mockData, options.transform, options.map, options.useMock, options.logRequests);
 	}
 
 	createParentSingletonResource<TDataType, TResourceDictionaryType>
 		(options: IParentSingletonResourceParams<TDataType, TResourceDictionaryType>): IBaseParentSingletonDataService<TDataType, TResourceDictionaryType> {
 		options = this.useMockIfNoEndpoint(options);
-		return new BaseParentSingletonDataService(this.$http, this.$q, options.endpoint, options.mockData, options.resourceDictionaryBuilder, options.transform, options.useMock, options.logRequests);
+		return new BaseParentSingletonDataService(this.$http, this.$q, options.endpoint, options.mockData, options.resourceDictionaryBuilder, options.transform, options.map, options.useMock, options.logRequests);
 	}
 
 	private useMockIfNoEndpoint<TDataType>(options: IBaseOptions<TDataType>): IBaseOptions<TDataType> {

--- a/source/services/dataContracts/baseSingletonDataService/baseSingletonData.service.ts
+++ b/source/services/dataContracts/baseSingletonDataService/baseSingletonData.service.ts
@@ -26,7 +26,8 @@ export class BaseSingletonDataService<TDataType> implements IBaseSingletonDataSe
             , transform: ITransform<TDataType>
             , public useMock: boolean
             , public logRequests: boolean) {
-        this.behavior = new BaseDataServiceBehavior($http, $q, transform);
+		// needs map property
+		this.behavior = new BaseDataServiceBehavior($http, $q, transform, null);
     }
 
     get(): angular.IPromise<TDataType> {

--- a/source/services/dataContracts/baseSingletonDataService/baseSingletonData.service.ts
+++ b/source/services/dataContracts/baseSingletonDataService/baseSingletonData.service.ts
@@ -3,7 +3,7 @@
 import * as angular from 'angular';
 import * as _ from 'lodash';
 
-import { IBaseDataServiceBehavior, BaseDataServiceBehavior, ITransform } from '../baseDataServiceBehavior';
+import { IBaseDataServiceBehavior, BaseDataServiceBehavior, IConverter, ITransform } from '../baseDataServiceBehavior';
 
 export var moduleName: string = 'rl.utilities.services.baseSingletonDataService';
 export var factoryName: string = 'baseSingletonDataService';
@@ -24,10 +24,10 @@ export class BaseSingletonDataService<TDataType> implements IBaseSingletonDataSe
             , public endpoint: string
             , private mockData: TDataType
             , transform: ITransform<TDataType>
+			, map: { [index: string]: IConverter<TDataType> }
             , public useMock: boolean
             , public logRequests: boolean) {
-		// needs map property
-		this.behavior = new BaseDataServiceBehavior($http, $q, transform, null);
+		this.behavior = new BaseDataServiceBehavior($http, $q, transform, map);
     }
 
     get(): angular.IPromise<TDataType> {
@@ -53,14 +53,14 @@ export class BaseSingletonDataService<TDataType> implements IBaseSingletonDataSe
 }
 
 export interface IBaseSingletonDataServiceFactory {
-    getInstance<TDataType>(endpoint: string, mockData?: TDataType, transform?: ITransform<TDataType>, useMock?: boolean): IBaseSingletonDataService<TDataType>;
+    getInstance<TDataType>(endpoint: string, mockData?: TDataType, transform?: ITransform<TDataType>, map?: { [index: string]: IConverter<TDataType> }, useMock?: boolean): IBaseSingletonDataService<TDataType>;
 }
 
 baseSingletonDataServiceFactory.$inject = ['$http', '$q'];
 export function baseSingletonDataServiceFactory($http: angular.IHttpService, $q: angular.IQService): IBaseSingletonDataServiceFactory {
     return {
-        getInstance<TDataType>(endpoint: string, mockData?: TDataType, transform?: ITransform<TDataType>, useMock?: boolean, logRequests?: boolean): IBaseSingletonDataService<TDataType> {
-            return new BaseSingletonDataService<TDataType>($http, $q, endpoint, mockData, transform, useMock, logRequests);
+        getInstance<TDataType>(endpoint: string, mockData?: TDataType, transform?: ITransform<TDataType>, map?: { [index: string]: IConverter<TDataType> }, useMock?: boolean, logRequests?: boolean): IBaseSingletonDataService<TDataType> {
+            return new BaseSingletonDataService<TDataType>($http, $q, endpoint, mockData, transform, map, useMock, logRequests);
         },
     };
 }


### PR DESCRIPTION
Added the ability to specify a map object for a resource. The map object specifies the keys of properties that need to be mapped, and the value should specify a transform object for that property. Properties that are not specified will be returned as-is. Also, by leaving the existing tests as-is, we ensure that this change is backwards compatible with the current transform so we don't have to replace all references. Currently, if a transform and map object are both provided, only the transform will be used.

The next step will be to provide transforms for common data types, such as date and enum.
