### PR TITLE
Common converters

### DIFF
--- a/source/services/dataContracts/baseDataService/baseData.service.ts
+++ b/source/services/dataContracts/baseDataService/baseData.service.ts
@@ -35,7 +35,8 @@ export class BaseDataService<TDataType extends IBaseDomainObject, TSearchParams>
             , transform: ITransform<TDataType>
             , public useMock: boolean
             , public logRequests: boolean) {
-        this.behavior = new BaseDataServiceBehavior($http, $q, transform);
+		// needs map property
+		this.behavior = new BaseDataServiceBehavior($http, $q, transform, null);
     }
 
     private getItemEndpoint(id: number): string {

--- a/source/services/dataContracts/baseDataService/baseData.service.ts
+++ b/source/services/dataContracts/baseDataService/baseData.service.ts
@@ -4,7 +4,7 @@ import * as angular from 'angular';
 import * as _ from 'lodash';
 
 import { IArrayUtility, serviceName as arrayServiceName, moduleName as arrayModuleName } from '../../array/array.service';
-import { IBaseDataServiceBehavior, BaseDataServiceBehavior, ITransform } from '../baseDataServiceBehavior';
+import { IBaseDataServiceBehavior, BaseDataServiceBehavior, IConverter, ITransform } from '../baseDataServiceBehavior';
 
 export var moduleName: string = 'rl.utilities.services.baseDataService';
 export var factoryName: string = 'baseDataService';
@@ -33,10 +33,10 @@ export class BaseDataService<TDataType extends IBaseDomainObject, TSearchParams>
             , public endpoint: string
             , protected mockData: TDataType[]
             , transform: ITransform<TDataType>
+			, map: { [index: string]: IConverter<TDataType> }
             , public useMock: boolean
             , public logRequests: boolean) {
-		// needs map property
-		this.behavior = new BaseDataServiceBehavior($http, $q, transform, null);
+		this.behavior = new BaseDataServiceBehavior($http, $q, transform, map);
     }
 
     private getItemEndpoint(id: number): string {
@@ -110,15 +110,15 @@ export class BaseDataService<TDataType extends IBaseDomainObject, TSearchParams>
 
 export interface IBaseDataServiceFactory {
     getInstance<TDataType extends IBaseDomainObject, TSearchParams>(endpoint: string, mockData?: TDataType[]
-        , transform?: ITransform<TDataType>, useMock?: boolean): IBaseDataService<TDataType, TSearchParams>;
+        , transform?: ITransform<TDataType>, map?: { [index: string]: IConverter<TDataType> }, useMock?: boolean): IBaseDataService<TDataType, TSearchParams>;
 }
 
 baseDataServiceFactory.$inject = ['$http', '$q', arrayServiceName];
 export function baseDataServiceFactory($http: angular.IHttpService, $q: angular.IQService, array: IArrayUtility): IBaseDataServiceFactory {
     return {
         getInstance<TDataType extends IBaseDomainObject, TSearchParams>(endpoint: string, mockData?: TDataType[]
-            , transform?: ITransform<TDataType>, useMock?: boolean, logRequests?: boolean): IBaseDataService<TDataType, TSearchParams> {
-            return new BaseDataService<TDataType, TSearchParams>($http, $q, array, endpoint, mockData, transform, useMock, logRequests);
+            , transform?: ITransform<TDataType>, map?: { [index: string]: IConverter<TDataType> }, useMock?: boolean, logRequests?: boolean): IBaseDataService<TDataType, TSearchParams> {
+            return new BaseDataService<TDataType, TSearchParams>($http, $q, array, endpoint, mockData, transform, map, useMock, logRequests);
         },
     };
 }

--- a/source/services/dataContracts/baseDataService/baseDataServiceView.ts
+++ b/source/services/dataContracts/baseDataService/baseDataServiceView.ts
@@ -2,7 +2,7 @@
 
 import { IArrayUtility, serviceName as arrayServiceName, moduleName as arrayModuleName } from '../../array/array.service';
 
-import { ITransform } from '../baseDataServiceBehavior';
+import { IConverter, ITransform } from '../baseDataServiceBehavior';
 import { IBaseDataService, BaseDataService, IBaseDomainObject } from './baseData.service';
 import { IBaseParentDataService, BaseParentDataService } from '../baseParentDataService/baseParentData.service';
 import { IBaseSingletonDataService, BaseSingletonDataService } from '../baseSingletonDataService/baseSingletonData.service';
@@ -26,16 +26,17 @@ export class BaseDataServiceView<TDataType extends IBaseDomainObject, TSearchPar
             , _endpoint: string
             , mockData: TDataType[]
             , private transform: ITransform<TDataType>
+			, private map: { [index: string]: IConverter<TDataType> }
             , useMock: boolean
             , logRequests: boolean) {
-		super($http, $q, array, _endpoint, mockData, transform, useMock, logRequests);
+		super($http, $q, array, _endpoint, mockData, transform, map, useMock, logRequests);
 	}
 
 	AsSingleton(parentId: number): IBaseSingletonDataService<TDataType> {
 		let mockData: TDataType = _.find(this.mockData, (item: TDataType): boolean => {
 			return item.id === parentId;
 		});
-		return new BaseSingletonDataService<TDataType>(this.$http, this.$q, this.endpoint, mockData, this.transform, this.useMock, this.logRequests);
+		return new BaseSingletonDataService<TDataType>(this.$http, this.$q, this.endpoint, mockData, this.transform, this.map, this.useMock, this.logRequests);
 	}
 }
 
@@ -49,15 +50,16 @@ export class BaseParentDataServiceView<TDataType extends IBaseDomainObject, TSea
             , mockData: TDataType[]
 			, resourceDictionaryBuilder: {(): TResourceDictionaryType}
             , private transform: ITransform<TDataType>
+			, private map: { [index: string]: IConverter<TDataType> }
             , useMock: boolean
             , logRequests: boolean) {
-		super($http, $q, array, _endpoint, mockData, resourceDictionaryBuilder, transform, useMock, logRequests);
+		super($http, $q, array, _endpoint, mockData, resourceDictionaryBuilder, transform, map, useMock, logRequests);
 	}
 
 	AsSingleton(parentId: number): IBaseParentSingletonDataService<TDataType, TResourceDictionaryType> {
 		let mockData: TDataType = _.find(this.mockData, (item: TDataType): boolean => {
 			return item.id === parentId;
 		});
-		return new BaseParentSingletonDataService<TDataType, TResourceDictionaryType>(this.$http, this.$q, this.endpoint, mockData, this.resourceDictionaryBuilder, this.transform, this.useMock, this.logRequests, parentId);
+		return new BaseParentSingletonDataService<TDataType, TResourceDictionaryType>(this.$http, this.$q, this.endpoint, mockData, this.resourceDictionaryBuilder, this.transform, this.map, this.useMock, this.logRequests, parentId);
 	}
 }

--- a/source/services/dataContracts/baseDataServiceBehavior.tests.ts
+++ b/source/services/dataContracts/baseDataServiceBehavior.tests.ts
@@ -20,6 +20,12 @@ interface ITestMock {
 	prop?: string;
 }
 
+interface ITestMock2 {
+	id?: number;
+	prop1?: number;
+	prop2?: number;
+}
+
 describe('base data service behavior', () => {
 	let dataServiceBehavior: IBaseDataServiceBehavior<ITestMock>;
 
@@ -278,6 +284,7 @@ describe('base data service behavior', () => {
 		let $rootScope: angular.IRootScopeService;
 		let dataSet: ITestMock[];
 		let transform: any;
+		let numberConverter: any;
 
 		beforeEach((): void => {
 			dataSet = [
@@ -297,6 +304,15 @@ describe('base data service behavior', () => {
                     return {
                         prop: data,
                     };
+                }),
+			};
+
+			numberConverter = {
+				fromServer: sinon.spy((rawData: number): number => {
+					return rawData + 1;
+                }),
+                toServer: sinon.spy((data: number): number => {
+                    return data - 1;
                 }),
 			};
 
@@ -356,6 +372,81 @@ describe('base data service behavior', () => {
 
             expect(updateSpy.firstCall.args[0].prop).to.equal('made some changes');
             sinon.assert.calledOnce(transform.toServer);
+
+			$rootScope.$digest();
+        });
+	});
+
+	describe('map', (): void => {
+		let $rootScope: angular.IRootScopeService;
+		let numberConverter: any;
+
+		beforeEach((): void => {
+			let services: any = angularFixture.inject('$rootScope', '$q', '$http');
+			$rootScope = services.$rootScope;
+
+			numberConverter = {
+				fromServer: sinon.spy((rawData: number): number => {
+					return rawData + 1;
+                }),
+                toServer: sinon.spy((data: number): number => {
+                    return data - 1;
+                }),
+			};
+
+			let map: any = {
+				prop1: numberConverter,
+			};
+
+			dataServiceBehavior = new BaseDataServiceBehavior<ITestMock>(services.$http, services.$q, null, map);
+		});
+
+		it('should use a an object map to transform properties from the server', (done: MochaDone): void => {
+			let item: ITestMock2 = {
+				prop1: 4,
+				prop2: 4,
+			};
+
+			dataServiceBehavior.getItem({
+                useMock: true,
+                getMockData(): ITestMock { return item; },
+                endpoint: null,
+                logRequests: false,
+            }).then((data: ITestMock2): void => {
+				expect(data.prop1).to.equal(5);
+				expect(data.prop2).to.equal(4);
+				sinon.assert.calledOnce(numberConverter.fromServer);
+				done();
+			});
+
+			$rootScope.$digest();
+		});
+
+        it('should use an object map to transform properties for sending back to the server', (done: MochaDone): void => {
+			let updatedItem: ITestMock2 = {
+				prop1: 5,
+				prop2: 4,
+			};
+
+			let updateSpy: Sinon.SinonSpy = sinon.spy();
+
+            dataServiceBehavior.update({
+                domainObject: updatedItem,
+                useMock: true,
+                updateMockData: updateSpy,
+                endpoint: null,
+                logRequests: false,
+            }).then((data: ITestMock2): void => {
+                expect(data.prop1).to.equal(4);
+                expect(data.prop2).to.equal(4);
+				sinon.assert.calledOnce(numberConverter.fromServer);
+				done();
+            });
+
+            sinon.assert.calledOnce(updateSpy);
+			let updateArg: any = updateSpy.firstCall.args[0];
+            expect(updateArg.prop1).to.equal(4);
+            expect(updateArg.prop2).to.equal(4);
 
 			$rootScope.$digest();
         });

--- a/source/services/dataContracts/baseDataServiceBehavior.tests.ts
+++ b/source/services/dataContracts/baseDataServiceBehavior.tests.ts
@@ -437,7 +437,7 @@ describe('base data service behavior', () => {
                 endpoint: null,
                 logRequests: false,
             }).then((data: ITestMock2): void => {
-                expect(data.prop1).to.equal(4);
+                expect(data.prop1).to.equal(5);
                 expect(data.prop2).to.equal(4);
 				sinon.assert.calledOnce(numberConverter.fromServer);
 				done();

--- a/source/services/dataContracts/baseDataServiceBehavior.tests.ts
+++ b/source/services/dataContracts/baseDataServiceBehavior.tests.ts
@@ -43,7 +43,7 @@ describe('base data service behavior', () => {
 			$httpBackend = services.$httpBackend;
 
 			testUrl = '/api/test';
-			dataServiceBehavior = new BaseDataServiceBehavior<ITestMock>(services.$http, services.$q, null);
+			dataServiceBehavior = new BaseDataServiceBehavior<ITestMock>(services.$http, services.$q, null, null);
 		});
 
 		afterEach((): void => {
@@ -173,7 +173,7 @@ describe('base data service behavior', () => {
             $rootScope = services.$rootScope;
             array = services[arrayService];
 
-			dataServiceBehavior = new BaseDataServiceBehavior<ITestMock>(services.$http, services.$q, null);
+			dataServiceBehavior = new BaseDataServiceBehavior<ITestMock>(services.$http, services.$q, null, null);
 		});
 
 		it('should get the mocked data set', (done: MochaDone): void => {
@@ -316,7 +316,7 @@ describe('base data service behavior', () => {
                 }),
 			};
 
-			dataServiceBehavior = new BaseDataServiceBehavior<ITestMock>(services.$http, services.$q, transform);
+			dataServiceBehavior = new BaseDataServiceBehavior<ITestMock>(services.$http, services.$q, transform, null);
 		});
 
 		it('should transform each entry in the list', (done: MochaDone): void => {

--- a/source/services/dataContracts/baseDataServiceBehavior.ts
+++ b/source/services/dataContracts/baseDataServiceBehavior.ts
@@ -4,7 +4,7 @@ import * as angular from 'angular';
 import * as _ from 'lodash';
 
 export interface IConverter<TDataType> {
-	fromServer(raw: TDataType): TDataType;
+	fromServer(raw: any): TDataType;
     toServer(data: TDataType): any,
 }
 

--- a/source/services/dataContracts/baseDataServiceBehavior.ts
+++ b/source/services/dataContracts/baseDataServiceBehavior.ts
@@ -162,7 +162,7 @@ export class BaseDataServiceBehavior<TDataType> implements IBaseDataServiceBehav
 		if (this.transform != null) {
 			return this.transform.fromServer(rawData);
 		} else if (this.map != null) {
-			return <any>_.map(rawData, (prop: any, key: string): any => {
+			return <any>_.mapValues(rawData, (prop: any, key: string): any => {
 				if (_.has(this.map, key)) {
 					return this.map[key].fromServer(prop);
 				}
@@ -177,7 +177,7 @@ export class BaseDataServiceBehavior<TDataType> implements IBaseDataServiceBehav
 		if (this.transform != null) {
 			return this.transform.toServer(data);
 		} else if (this.map != null) {
-			return <any>_.map(data, (prop: any, key: string): any => {
+			return <any>_.mapValues(data, (prop: any, key: string): any => {
 				if (_.has(this.map, key)) {
 					return this.map[key].toServer(prop);
 				}

--- a/source/services/dataContracts/baseParentDataService/baseParentData.service.ts
+++ b/source/services/dataContracts/baseParentDataService/baseParentData.service.ts
@@ -3,7 +3,7 @@ import * as _ from 'lodash';
 
 import { IArrayUtility } from '../../array/array.service';
 
-import { ITransform } from '../baseDataServiceBehavior';
+import { IConverter, ITransform } from '../baseDataServiceBehavior';
 import { IBaseDataService, BaseDataService, IBaseDomainObject } from '../baseDataService/baseData.service';
 import { IBaseDataServiceView } from '../baseDataService/baseDataServiceView';
 import { IBaseSingletonDataService } from '../baseSingletonDataService/baseSingletonData.service';
@@ -18,9 +18,10 @@ export class BaseParentDataService<TDataType extends IBaseDomainObject, TSearchP
 	constructor($http: ng.IHttpService, $q: ng.IQService, array: IArrayUtility, endpoint: string, mockData: TDataType[]
 		, public resourceDictionaryBuilder: { (): TResourceDictionaryType }
 		, transform?: ITransform<TDataType>
+		, map?: { [index: string]: IConverter<TDataType> }
 		, useMock?: boolean
         , logRequests?: boolean) {
-		super($http, $q, array, endpoint, mockData, transform, useMock, logRequests);
+		super($http, $q, array, endpoint, mockData, transform, map, useMock, logRequests);
 	}
 
 	childContracts(id?: number): TResourceDictionaryType {

--- a/source/services/dataContracts/baseParentSingletonDataService/baseParentSingletonData.service.ts
+++ b/source/services/dataContracts/baseParentSingletonDataService/baseParentSingletonData.service.ts
@@ -1,6 +1,6 @@
 import * as ng from 'angular';
 
-import { ITransform } from '../baseDataServiceBehavior';
+import { IConverter, ITransform } from '../baseDataServiceBehavior';
 import { IBaseSingletonDataService, BaseSingletonDataService } from '../baseSingletonDataService/baseSingletonData.service';
 import { IBaseDataService, BaseDataService, IBaseDomainObject } from '../baseDataService/baseData.service';
 import { IBaseDataServiceView } from '../baseDataService/baseDataServiceView';
@@ -15,10 +15,11 @@ export class BaseParentSingletonDataService<TDataType, TResourceDictionaryType>
 	constructor($http: ng.IHttpService, $q: ng.IQService, endpoint: string, mockData: TDataType
 		, private resourceDictionaryBuilder: { (): TResourceDictionaryType }
 		, transform?: ITransform<TDataType>
+		, map?: { [index: string]: IConverter<TDataType> }
 		, useMock?: boolean
 		, logRequests?: boolean
 		, private parentId?: number) {
-		super($http, $q, endpoint, mockData, transform, useMock, logRequests);
+		super($http, $q, endpoint, mockData, transform, map, useMock, logRequests);
 	}
 
 	childContracts(): TResourceDictionaryType {

--- a/source/services/dataContracts/baseResourceBuilder/baseResourceBuilder.service.ts
+++ b/source/services/dataContracts/baseResourceBuilder/baseResourceBuilder.service.ts
@@ -5,7 +5,7 @@ import * as angular from 'angular';
 import { IArrayUtility, serviceName as arrayServiceName, moduleName as arrayModuleName } from '../../array/array.service';
 
 import { IContractLibrary, ContractLibrary, ILibraryServices } from './contractLibrary';
-import { ITransform } from '../baseDataServiceBehavior';
+import { IConverter, ITransform } from '../baseDataServiceBehavior';
 import { IBaseDataService, BaseDataService, IBaseDomainObject } from '../baseDataService/baseData.service';
 import { IBaseDataServiceView, IBaseParentDataServiceView, BaseDataServiceView, BaseParentDataServiceView } from '../baseDataService/baseDataServiceView';
 import { IBaseParentDataService, BaseParentDataService } from '../baseParentDataService/baseParentData.service';
@@ -32,6 +32,11 @@ export interface IBaseOptions<TDataType> {
 	* Flag for specifying if the data service should log all requests against the contract
 	*/
 	logRequests?: boolean;
+
+	/**
+	* Mapping to specify how properties should be transformed to and from the server
+	*/
+	map?: { [index: string]: IConverter<TDataType> };
 
 	/**
 	* Processes data coming back from the server
@@ -145,35 +150,35 @@ export class BaseResourceBuilder implements IBaseResourceBuilder {
 
 	createResource<TDataType extends IBaseDomainObject, TSearchParams>(options: IBaseResourceParams<TDataType>): IBaseDataService<TDataType, TSearchParams> {
 		options = this.useMockIfNoEndpoint(options);
-		return new BaseDataService(this.$http, this.$q, this.array, options.endpoint, options.mockData, options.transform, options.useMock, options.logRequests);
+		return new BaseDataService(this.$http, this.$q, this.array, options.endpoint, options.mockData, options.transform, options.map, options.useMock, options.logRequests);
 	}
 
 	createResourceView<TDataType extends IBaseDomainObject, TSearchParams>(options: IBaseResourceParams<TDataType>): IBaseDataServiceView<TDataType, TSearchParams> {
 		options = this.useMockIfNoEndpoint(options);
-		return new BaseDataServiceView(this.$http, this.$q, this.array, options.endpoint, options.mockData, options.transform, options.useMock, options.logRequests);
+		return new BaseDataServiceView(this.$http, this.$q, this.array, options.endpoint, options.mockData, options.transform, options.map, options.useMock, options.logRequests);
 	}
 
 	createParentResource<TDataType extends IBaseDomainObject, TSearchParams, TResourceDictionaryType>
 		(options: IParentResourceParams<TDataType, TResourceDictionaryType>): IBaseParentDataService<TDataType, TSearchParams, TResourceDictionaryType> {
 		options = this.useMockIfNoEndpoint(options);
-		return new BaseParentDataService(this.$http, this.$q, this.array, options.endpoint, options.mockData, options.resourceDictionaryBuilder, options.transform, options.useMock, options.logRequests);
+		return new BaseParentDataService(this.$http, this.$q, this.array, options.endpoint, options.mockData, options.resourceDictionaryBuilder, options.transform, options.map, options.useMock, options.logRequests);
 	}
 
 	createParentResourceView<TDataType extends IBaseDomainObject, TSearchParams, TResourceDictionaryType>
 		(options: IParentResourceParams<TDataType, TResourceDictionaryType>): IBaseParentDataServiceView<TDataType, TSearchParams, TResourceDictionaryType> {
 		options = this.useMockIfNoEndpoint(options);
-		return new BaseParentDataServiceView(this.$http, this.$q, this.array, options.endpoint, options.mockData, options.resourceDictionaryBuilder, options.transform, options.useMock, options.logRequests);
+		return new BaseParentDataServiceView(this.$http, this.$q, this.array, options.endpoint, options.mockData, options.resourceDictionaryBuilder, options.transform, options.map, options.useMock, options.logRequests);
 	}
 
 	createSingletonResource<TDataType>(options: ISingletonResourceParams<TDataType>): IBaseSingletonDataService<TDataType> {
 		options = this.useMockIfNoEndpoint(options);
-		return new BaseSingletonDataService(this.$http, this.$q, options.endpoint, options.mockData, options.transform, options.useMock, options.logRequests);
+		return new BaseSingletonDataService(this.$http, this.$q, options.endpoint, options.mockData, options.transform, options.map, options.useMock, options.logRequests);
 	}
 
 	createParentSingletonResource<TDataType, TResourceDictionaryType>
 		(options: IParentSingletonResourceParams<TDataType, TResourceDictionaryType>): IBaseParentSingletonDataService<TDataType, TResourceDictionaryType> {
 		options = this.useMockIfNoEndpoint(options);
-		return new BaseParentSingletonDataService(this.$http, this.$q, options.endpoint, options.mockData, options.resourceDictionaryBuilder, options.transform, options.useMock, options.logRequests);
+		return new BaseParentSingletonDataService(this.$http, this.$q, options.endpoint, options.mockData, options.resourceDictionaryBuilder, options.transform, options.map, options.useMock, options.logRequests);
 	}
 
 	private useMockIfNoEndpoint<TDataType>(options: IBaseOptions<TDataType>): IBaseOptions<TDataType> {

--- a/source/services/dataContracts/baseSingletonDataService/baseSingletonData.service.ts
+++ b/source/services/dataContracts/baseSingletonDataService/baseSingletonData.service.ts
@@ -26,7 +26,8 @@ export class BaseSingletonDataService<TDataType> implements IBaseSingletonDataSe
             , transform: ITransform<TDataType>
             , public useMock: boolean
             , public logRequests: boolean) {
-        this.behavior = new BaseDataServiceBehavior($http, $q, transform);
+		// needs map property
+		this.behavior = new BaseDataServiceBehavior($http, $q, transform, null);
     }
 
     get(): angular.IPromise<TDataType> {

--- a/source/services/dataContracts/baseSingletonDataService/baseSingletonData.service.ts
+++ b/source/services/dataContracts/baseSingletonDataService/baseSingletonData.service.ts
@@ -3,7 +3,7 @@
 import * as angular from 'angular';
 import * as _ from 'lodash';
 
-import { IBaseDataServiceBehavior, BaseDataServiceBehavior, ITransform } from '../baseDataServiceBehavior';
+import { IBaseDataServiceBehavior, BaseDataServiceBehavior, IConverter, ITransform } from '../baseDataServiceBehavior';
 
 export var moduleName: string = 'rl.utilities.services.baseSingletonDataService';
 export var factoryName: string = 'baseSingletonDataService';
@@ -24,10 +24,10 @@ export class BaseSingletonDataService<TDataType> implements IBaseSingletonDataSe
             , public endpoint: string
             , private mockData: TDataType
             , transform: ITransform<TDataType>
+			, map: { [index: string]: IConverter<TDataType> }
             , public useMock: boolean
             , public logRequests: boolean) {
-		// needs map property
-		this.behavior = new BaseDataServiceBehavior($http, $q, transform, null);
+		this.behavior = new BaseDataServiceBehavior($http, $q, transform, map);
     }
 
     get(): angular.IPromise<TDataType> {
@@ -53,14 +53,14 @@ export class BaseSingletonDataService<TDataType> implements IBaseSingletonDataSe
 }
 
 export interface IBaseSingletonDataServiceFactory {
-    getInstance<TDataType>(endpoint: string, mockData?: TDataType, transform?: ITransform<TDataType>, useMock?: boolean): IBaseSingletonDataService<TDataType>;
+    getInstance<TDataType>(endpoint: string, mockData?: TDataType, transform?: ITransform<TDataType>, map?: { [index: string]: IConverter<TDataType> }, useMock?: boolean): IBaseSingletonDataService<TDataType>;
 }
 
 baseSingletonDataServiceFactory.$inject = ['$http', '$q'];
 export function baseSingletonDataServiceFactory($http: angular.IHttpService, $q: angular.IQService): IBaseSingletonDataServiceFactory {
     return {
-        getInstance<TDataType>(endpoint: string, mockData?: TDataType, transform?: ITransform<TDataType>, useMock?: boolean, logRequests?: boolean): IBaseSingletonDataService<TDataType> {
-            return new BaseSingletonDataService<TDataType>($http, $q, endpoint, mockData, transform, useMock, logRequests);
+        getInstance<TDataType>(endpoint: string, mockData?: TDataType, transform?: ITransform<TDataType>, map?: { [index: string]: IConverter<TDataType> }, useMock?: boolean, logRequests?: boolean): IBaseSingletonDataService<TDataType> {
+            return new BaseSingletonDataService<TDataType>($http, $q, endpoint, mockData, transform, map, useMock, logRequests);
         },
     };
 }

--- a/source/services/dataContracts/converters/converters.ts
+++ b/source/services/dataContracts/converters/converters.ts
@@ -1,0 +1,3 @@
+'use strict';
+
+export * from './dateConverter/dateConverter';

--- a/source/services/dataContracts/converters/converters.ts
+++ b/source/services/dataContracts/converters/converters.ts
@@ -1,3 +1,4 @@
 'use strict';
 
 export * from './dateConverter/dateConverter';
+export * from './enumConverter/enumConverter';

--- a/source/services/dataContracts/converters/dateConverter/dateConverter.tests.ts
+++ b/source/services/dataContracts/converters/dateConverter/dateConverter.tests.ts
@@ -1,0 +1,26 @@
+/// <reference path='../../../../../typings/chai/chai.d.ts' />
+/// <reference path='../../../../../typings/mocha/mocha.d.ts' />
+/// <reference path='../../../../../typings/sinon/sinon.d.ts' />
+/// <reference path='../../../../../typings/chaiAssertions.d.ts' />
+
+'use strict';
+
+import * as angular from 'angular';
+import 'angular-mocks';
+
+import { services as utilityServices } from 'typescript-angular-utilities';
+import __test = utilityServices.test;
+
+import { dateConverter } from './dateConverter';
+
+describe('dateConverter', (): void => {
+	it('should get the date from an ISO string', (): void => {
+		var expectedDate = new Date(2015, 10, 24, 20, 12, 0);
+		expect(dateConverter.fromServer('2015-11-24T20:12:00')).to.deep.equal(expectedDate);
+	});
+
+	it('should convert the date to an ISO string', (): void => {
+		var date = new Date(2015, 10, 24, 20, 12, 0);
+		expect(dateConverter.toServer(date)).to.equal('2015-11-24T20:12:00');
+	});
+});

--- a/source/services/dataContracts/converters/dateConverter/dateConverter.tests.ts
+++ b/source/services/dataContracts/converters/dateConverter/dateConverter.tests.ts
@@ -5,12 +5,6 @@
 
 'use strict';
 
-import * as angular from 'angular';
-import 'angular-mocks';
-
-import { services as utilityServices } from 'typescript-angular-utilities';
-import __test = utilityServices.test;
-
 import { dateConverter } from './dateConverter';
 
 describe('dateConverter', (): void => {

--- a/source/services/dataContracts/converters/dateConverter/dateConverter.ts
+++ b/source/services/dataContracts/converters/dateConverter/dateConverter.ts
@@ -1,0 +1,15 @@
+'use strict';
+
+import * as moment from 'moment';
+
+import { IConverter } from '../../baseDataServiceBehavior';
+import { dateUtility, defaultFormats } from '../../../date/date.module';
+
+export let dateConverter: IConverter<Date> = {
+	fromServer(raw: string): Date {
+		return dateUtility.getDateFromISOString(raw);
+	},
+	toServer(data: Date): string {
+		return moment(data).format(defaultFormats.isoFormat);
+	},
+};

--- a/source/services/dataContracts/converters/enumConverter/enumConverter.tests.ts
+++ b/source/services/dataContracts/converters/enumConverter/enumConverter.tests.ts
@@ -43,5 +43,12 @@ describe('enumConverter', (): void => {
 		expect(enumConverter.toServer(testEnum.type2)).to.equal(1);
 	});
 
-	it('should ')
+	it('should return undefined if an invalid value is specified', (): void => {
+		expect(enumConverter.fromServer(10)).to.not.exist;
+		expect(enumConverter.fromServer(null)).to.not.exist;
+	});
+
+	it('should return null if the enum type is null', (): void => {
+		expect(enumConverter.toServer(null)).to.not.exist;
+	});
 });

--- a/source/services/dataContracts/converters/enumConverter/enumConverter.tests.ts
+++ b/source/services/dataContracts/converters/enumConverter/enumConverter.tests.ts
@@ -8,7 +8,7 @@
 import { EnumConverter, IConverter } from './enumConverter';
 import { ItemList, IItem } from '../../../../types/itemList';
 
-class TestEnum {
+class TestEnum extends ItemList {
 	type1: IItem = {
 		value: 0,
 		name: 'type1',

--- a/source/services/dataContracts/converters/enumConverter/enumConverter.tests.ts
+++ b/source/services/dataContracts/converters/enumConverter/enumConverter.tests.ts
@@ -6,19 +6,19 @@
 'use strict';
 
 import { EnumConverter, IConverter } from './enumConverter';
-import { ItemList, IItem } from '../../../types/itemList';
+import { ItemList, IItem } from '../../../../types/itemList';
 
-class TestEnum = {
+class TestEnum {
 	type1: IItem = {
 		value: 0,
 		name: 'type1',
 		display: 'Type 1',
-	},
+	};
 	type2: IItem = {
 		value: 1,
 		name: 'type2',
 		display: 'Type 2',
-	},
+	};
 
 	constructor() {
 		super();
@@ -42,4 +42,6 @@ describe('enumConverter', (): void => {
 		expect(enumConverter.toServer(testEnum.type1)).to.equal(0);
 		expect(enumConverter.toServer(testEnum.type2)).to.equal(1);
 	});
+
+	it('should ')
 });

--- a/source/services/dataContracts/converters/enumConverter/enumConverter.tests.ts
+++ b/source/services/dataContracts/converters/enumConverter/enumConverter.tests.ts
@@ -1,0 +1,45 @@
+/// <reference path='../../../../../typings/chai/chai.d.ts' />
+/// <reference path='../../../../../typings/mocha/mocha.d.ts' />
+/// <reference path='../../../../../typings/sinon/sinon.d.ts' />
+/// <reference path='../../../../../typings/chaiAssertions.d.ts' />
+
+'use strict';
+
+import { EnumConverter, IConverter } from './enumConverter';
+import { ItemList, IItem } from '../../../types/itemList';
+
+class TestEnum = {
+	type1: IItem = {
+		value: 0,
+		name: 'type1',
+		display: 'Type 1',
+	},
+	type2: IItem = {
+		value: 1,
+		name: 'type2',
+		display: 'Type 2',
+	},
+
+	constructor() {
+		super();
+
+		super.setItems([
+			this.type1,
+			this.type2,
+		]);
+	}
+}
+let testEnum = new TestEnum();
+let enumConverter: IConverter<IItem> = new EnumConverter(testEnum);
+
+describe('enumConverter', (): void => {
+	it('should get the enum type for the specified value', (): void => {
+		expect(enumConverter.fromServer(0)).to.equal(testEnum.type1);
+		expect(enumConverter.fromServer(1)).to.equal(testEnum.type2);
+	});
+
+	it('should get the value of the enum type', (): void => {
+		expect(enumConverter.toServer(testEnum.type1)).to.equal(0);
+		expect(enumConverter.toServer(testEnum.type2)).to.equal(1);
+	});
+});

--- a/source/services/dataContracts/converters/enumConverter/enumConverter.tests.ts
+++ b/source/services/dataContracts/converters/enumConverter/enumConverter.tests.ts
@@ -8,7 +8,7 @@
 import { EnumConverter, IConverter } from './enumConverter';
 import { ItemList, IItem } from '../../../../types/itemList';
 
-class TestEnum extends ItemList {
+class TestEnum extends ItemList<IItem> {
 	type1: IItem = {
 		value: 0,
 		name: 'type1',

--- a/source/services/dataContracts/converters/enumConverter/enumConverter.ts
+++ b/source/services/dataContracts/converters/enumConverter/enumConverter.ts
@@ -1,0 +1,21 @@
+'use strict';
+
+import * as moment from 'moment';
+
+import { IConverter } from '../../baseDataServiceBehavior';
+import { IItemList, IItem } from '../../../../types/itemList';
+
+export { IConverter };
+
+export class EnumConverter implements IConverter<IItemList> {
+	constructor(private enumType: IItemList) {}
+
+	fromServer(raw: number): IItem {
+		return this.enumType.get(raw);
+	},
+	toServer(data: IItem): number {
+		return data != null
+			? data.value
+			: null;
+	},
+};

--- a/source/services/dataContracts/converters/enumConverter/enumConverter.ts
+++ b/source/services/dataContracts/converters/enumConverter/enumConverter.ts
@@ -12,10 +12,10 @@ export class EnumConverter<TItemType extends IItem> implements IConverter<IItemL
 
 	fromServer(raw: number): TItemType {
 		return this.enumType.get(raw);
-	},
+	}
 	toServer(data: TItemType): number {
 		return data != null
 			? data.value
 			: null;
-	},
+	}
 };

--- a/source/services/dataContracts/converters/enumConverter/enumConverter.ts
+++ b/source/services/dataContracts/converters/enumConverter/enumConverter.ts
@@ -7,13 +7,13 @@ import { IItemList, IItem } from '../../../../types/itemList';
 
 export { IConverter };
 
-export class EnumConverter implements IConverter<IItemList> {
-	constructor(private enumType: IItemList) {}
+export class EnumConverter<TItemType extends IItem> implements IConverter<IItemList<TItemType>> {
+	constructor(private enumType: IItemList<TItemType>) {}
 
-	fromServer(raw: number): IItem {
+	fromServer(raw: number): TItemType {
 		return this.enumType.get(raw);
 	},
-	toServer(data: IItem): number {
+	toServer(data: TItemType): number {
 		return data != null
 			? data.value
 			: null;

--- a/source/services/dataContracts/converters/enumConverter/enumConverter.ts
+++ b/source/services/dataContracts/converters/enumConverter/enumConverter.ts
@@ -7,7 +7,7 @@ import { IItemList, IItem } from '../../../../types/itemList';
 
 export { IConverter };
 
-export class EnumConverter<TItemType extends IItem> implements IConverter<IItemList<TItemType>> {
+export class EnumConverter<TItemType extends IItem> implements IConverter<TItemType> {
 	constructor(private enumType: IItemList<TItemType>) {}
 
 	fromServer(raw: number): TItemType {

--- a/source/services/dataContracts/dataContracts.module.ts
+++ b/source/services/dataContracts/dataContracts.module.ts
@@ -6,6 +6,7 @@ import { moduleName as resourceBuilderModuleName } from './baseResourceBuilder/b
 import { moduleName as baseDataServiceModuleName } from './baseDataService/baseData.service';
 import { moduleName as baseSingletonDataServiceModuleName } from './baseSingletonDataService/baseSingletonData.service';
 
+import * as converters from './converters/converters';
 import * as mocks from './baseResourceBuilder/dataServiceMocks';
 
 export var moduleName: string = 'rl.utilities.services.dataContracts';
@@ -17,7 +18,7 @@ export * from './baseParentDataService/baseParentData.service';
 export { IBaseSingletonDataService, IBaseSingletonDataServiceFactory, BaseSingletonDataService, factoryName as baseSingletonDataServiceFactoryName } from './baseSingletonDataService/baseSingletonData.service';
 export * from './baseParentSingletonDataService/baseParentSingletonData.service';
 export { IBaseResourceBuilder, serviceName as builderServiceName } from './baseResourceBuilder/baseResourceBuilder.service';
-export { mocks };
+export { converters, mocks };
 
 angular.module(moduleName, [
 	baseDataServiceModuleName,

--- a/source/services/date/date.service.tests.ts
+++ b/source/services/date/date.service.tests.ts
@@ -75,7 +75,7 @@ describe('dateUtility', () => {
 		it('should handle dates in a user-defined format', (): void => {
 			var dateString: string = '2014-1-1T12:00:00';
 			var date: Date = new Date('1/1/2014');
-			expect(dateUtility.getDate(dateString, 'YYYY-MM-DDTHH:mm:ss').getDate()).to.equal(date.getDate());
+			expect(dateUtility.getDate(dateString, defaultFormats.isoFormat).getDate()).to.equal(date.getDate());
 		});
 	});
 

--- a/source/services/date/date.service.ts
+++ b/source/services/date/date.service.ts
@@ -5,14 +5,15 @@ import * as _ from 'lodash';
 import * as moment from 'moment';
 
 import {
-moduleName as timeModuleName,
-serviceName as timeServiceName,
-ITimeUtility,
+	moduleName as timeModuleName,
+	serviceName as timeServiceName,
+	ITimeUtility,
+	timeUtility,
 } from '../time/time.service';
 
 import {
-moduleName as momentModuleName,
-serviceName as momentServiceName,
+	moduleName as momentModuleName,
+	serviceName as momentServiceName,
 } from '../moment/moment.module';
 
 import { defaultFormats } from './dateTimeFormatStrings';
@@ -198,3 +199,5 @@ export class DateUtility {
 		}
 	}
 }
+
+export let dateUtility: IDateUtility = new DateUtility(moment, timeUtility);

--- a/source/services/date/dateTimeFormatStrings.ts
+++ b/source/services/date/dateTimeFormatStrings.ts
@@ -3,12 +3,14 @@
 export var dateTimeFormatServiceName: string = 'dateTimeFormatStrings';
 
 export interface IDateFormatStrings {
+	isoFormat: string;
 	dateTimeFormat: string;
 	dateFormat: string;
 	timeFormat: string;
 }
 
 export var defaultFormats: IDateFormatStrings = {
+	isoFormat: 'YYYY-MM-DDTHH:mm:ss',
 	dateTimeFormat: 'M/D/YYYY h:mm A',
 	dateFormat: 'M/D/YYYY',
 	timeFormat: 'h:mmA',

--- a/source/services/time/time.service.ts
+++ b/source/services/time/time.service.ts
@@ -30,5 +30,7 @@ export class TimeUtility {
 	}
 }
 
+export let timeUtility: ITimeUtility = new TimeUtility();
+
 angular.module(moduleName, [])
 	.service(serviceName, TimeUtility);

--- a/source/types/itemList.ts
+++ b/source/types/itemList.ts
@@ -1,0 +1,42 @@
+'use strict';
+
+import * as _ from 'lodash';
+
+export interface IItem {
+    value: number;
+    name: string;
+    display: string;
+}
+
+export interface IItemList<TItemType extends IItem> {
+	get(value: number | string): TItemType;
+	all(): TItemType[];
+}
+
+export class ItemList<TItemType extends IItem> {
+	private items: TItemType[];
+
+	setItems(items: TItemType[]): void {
+		this.items = items;
+	}
+
+	get(value: number | string): TItemType {
+		var predicate: { (item: TItemType): boolean };
+
+		if (typeof value === 'string') {
+			predicate = (item: TItemType): boolean => {
+				return (item.name === value);
+			};
+		} else {
+			predicate = (item: TItemType): boolean => {
+				return (item.value === value);
+			};
+		}
+
+		return _.find(this.items, predicate);
+	}
+
+	all(): TItemType[] {
+		return this.items;
+	}
+}

--- a/source/types/types.module.ts
+++ b/source/types/types.module.ts
@@ -1,3 +1,4 @@
 'use strict';
 
 export * from './compareResult';
+export * from './itemList';


### PR DESCRIPTION
Implemented converters for date and itemList enum types. These can be accessed as a namespace under dataContracts as:
`services.dataContracts.converters.dateConverter;` and
`new services.dataContracts.converters.EnumConverter(itemList);`

Requires https://github.com/RenovoSolutions/TypeScript-Angular-Utilities/pull/79
