### PR TITLE
Object areEqual datetime fix

### DIFF
--- a/source/services/date/date.service.tests.ts
+++ b/source/services/date/date.service.tests.ts
@@ -279,9 +279,9 @@ describe('dateUtility', () => {
 			expect(dateUtility.sameDate("5/10/1986", "5/10/1986")).to.be.true;
 			expect(dateUtility.sameDate("5/11/1986", "05/10/1986")).to.be.false;
 			expect(dateUtility.sameDate("2011-01-06 10:42:00", "1/6/2011 10:42", "YYYY-MM-DD H:mm", "MM/DD/YYYY HH:mm")).to.be.true;
-			expect(dateUtility.sameDate("2011-01-06 10:42:00", "1/6/2011 10:42", "YYYY-MM-DD H:mm")).to.be.true;
+			expect(dateUtility.sameDate("2011-01-06 10:42:00", "1/6/2011 10:42", "YYYY-MM-DD H:mm")).to.be.false;
 			expect(dateUtility.sameDate("2011-01-06 10:42:00", "2011-01-06 10:42:00", "YYYY-MM-DD H:mm")).to.be.true;
-			expect(dateUtility.sameDate("2011-01-06 10:42:00", "1/6/2011 10:43", "YYYY-MM-DD H:mm")).to.be.true;
+			expect(dateUtility.sameDate("2011-01-06 10:42:00", "1/6/2011 10:43", "YYYY-MM-DD H:mm")).to.be.false;
 			expect(dateUtility.sameDate("2011-01-06 10:42:00", "1/6/2011 10:42")).to.be.false;
 		});
 	});
@@ -295,7 +295,7 @@ describe('dateUtility', () => {
 			expect(dateUtility.sameDateTime('9/10/2000 10:00 AM', '9/10/2000 8:00 AM')).to.be.false;
 			expect(dateUtility.sameDateTime("2011-01-06 10:42:00", "1/6/2011 10:42")).to.be.false;
 			expect(dateUtility.sameDateTime("2011-01-06 10:42:00", "1/6/2011 10:42", "YYYY-MM-DD H:mm", "MM/DD/YYYY H:mm")).to.be.true;
-			expect(dateUtility.sameDateTime("2011-01-06 10:42:00", "1/6/2011 10:42", "YYYY-MM-DD H:mm")).to.be.true;
+			expect(dateUtility.sameDateTime("2011-01-06 10:42:00", "1/6/2011 10:42", "YYYY-MM-DD H:mm")).to.be.false;
 			expect(dateUtility.sameDateTime("2011-01-06 10:42:00", "1/6/2011 10:43", "YYYY-MM-DD H:mm")).to.be.false;
 			expect(dateUtility.sameDateTime("2011-01-06 10:42:00", "2011-01-06 10:42:00", "YYYY-MM-DD H:mm")).to.be.true;
 			expect(dateUtility.sameDateTime("2011-01-06 10:42:00", "1/6/2011 10:42")).to.be.false;

--- a/source/services/date/date.service.ts
+++ b/source/services/date/date.service.ts
@@ -158,8 +158,7 @@ export class DateUtility {
 		{
 			//lodash will return true if it is a valid date object, but has in invalid value.
 			//check the time value of the date object to verify that it's a Valid Date.
-			let r =!isNaN(date.getTime());
-			return r;
+			return !isNaN(date.getTime());
 		}
 		return this.moment(<string>date, this.getFormat(dateFormat)).isValid();
 	}
@@ -181,7 +180,7 @@ export class DateUtility {
 			date2Format = date1Format;
 		}
 		if (this.isDate(date1, date1Format) && this.isDate(date2, date2Format)) {
-			return moment(date1).format("MM/DD/YYYY") === moment(date2).format("MM/DD/YYYY");
+			return moment(<any>date1,date1Format).format("MM/DD/YYYY") === moment(<any>date2,date2Format).format("MM/DD/YYYY");
 		} else {
 			return false;
 		}
@@ -192,7 +191,7 @@ export class DateUtility {
 			date2Format = date1Format;
 		}
 		if (this.isDate(date1, date1Format) && this.isDate(date2, date2Format)) {
-			return moment(date1).format("MM/DD/YYYY +-HHmm") === moment(date2).format("MM/DD/YYYY +-HHmm");
+			return moment(<any>date1,date1Format).format("MM/DD/YYYY +-HHmm") === moment(<any>date2,date2Format).format("MM/DD/YYYY +-HHmm");
 		} else {
 			return false;
 		}

--- a/source/services/object/object.service.tests.ts
+++ b/source/services/object/object.service.tests.ts
@@ -88,6 +88,22 @@ describe('objectUtility', () => {
 			expect(objectUtility.areEqual(obj, null)).to.be.false;
 		});
 
+		it('should return false these objects are not equal', ():void => {
+			let object1 = {
+				name: 'objectName',
+				date: new Date('1/1/1901')
+			};
+			let object2 = {
+				name: 'objectName',
+				date:new Date('1/1/1901')
+			}
+
+			expect(objectUtility.areEqual(object1, object2)).to.be.true;
+
+			object2.date = new Date('1/2/1901');
+			expect(objectUtility.areEqual(object1, object2)).to.be.false;
+		});
+
 		it('should return false if arrays have different lengths', (): void => {
 			var array1: number[] = [1, 2, 3, 4, 5];
 			var array2: number[] = [1, 2, 3];

--- a/source/services/object/object.service.ts
+++ b/source/services/object/object.service.ts
@@ -9,6 +9,8 @@ import {
 	IArrayUtility
 } from '../array/array.service';
 
+import * as __dateUtility from '../date/date.module';
+
 export var moduleName: string = 'rl.utilities.services.object';
 export var serviceName: string = 'objectUtility';
 
@@ -27,9 +29,9 @@ export interface IObjectUtility {
 }
 
 class ObjectUtility implements IObjectUtility {
-		static $inject: string[] = [arrayServiceName];
-		constructor(private array: IArrayUtility) {
-		}
+	static $inject: string[] = [arrayServiceName, __dateUtility.serviceName];
+	constructor(private array: IArrayUtility, private dateUtility: __dateUtility.IDateUtility) {
+	}
 
 	isNullOrEmpty(object: any): boolean {
 		if (object == null) {
@@ -73,6 +75,8 @@ class ObjectUtility implements IObjectUtility {
 					return false;
 				}
 			}
+		} else if (_.isDate(obj1) && _.isDate(obj2)) {
+			return this.dateUtility.sameDateTime(obj1, obj2);
 		} else if (type1 === 'object') {
 			//init an object with the keys from obj2
 			var keys2: string[] = _.keys(obj2);
@@ -113,5 +117,5 @@ class ObjectUtility implements IObjectUtility {
 	}
 }
 
-angular.module(moduleName, [arrayModuleName])
+angular.module(moduleName, [arrayModuleName,__dateUtility.moduleName])
 	.service(serviceName, ObjectUtility);


### PR DESCRIPTION
when comparing objects, if the both objects had a property with the same name that was a date it was incorrectly saying they where equal if the date values where not the same.
added test and fix. 
