### PR TITLE
Allow for specifying a dataTransform when mocking a create or update …

### DIFF
--- a/source/services/dataContracts/contractLibrary/contractLibrary.ts
+++ b/source/services/dataContracts/contractLibrary/contractLibrary.ts
@@ -13,7 +13,7 @@ import {
 	ISingletonResourceParams,
 	IParentSingletonResourceParams,
 } from '../resourceBuilder/resourceBuilder.service';
-import { IDataServiceMock, IParentDataServiceMock, ISingletonDataServiceMock } from './dataServiceMocks';
+import { IDataServiceMock, IParentDataServiceMock, ISingletonDataServiceMock, IDataTransform } from './dataServiceMocks';
 import { IDataService, IBaseDomainObject } from '../dataService/data.service';
 import { IDataServiceView, IParentDataServiceView } from '../dataService/view/dataServiceView';
 import { IParentDataService, ParentDataService } from '../dataService/parent/parentData.service';
@@ -141,8 +141,8 @@ export class ContractLibrary implements IContractLibrary {
 		let dataService: IDataServiceMock<any, any> = <any>this.builder.createResource<any, any>({});
 		dataService.mockGetList = (data: any[]): Sinon.SinonSpy => { return this.baseMockGet(dataService, 'getList', data); };
 		dataService.mockGetDetail = (data: any): Sinon.SinonSpy => { return this.baseMockGet(dataService, 'get', data); };
-		dataService.mockUpdate = (): Sinon.SinonSpy => { return this.baseMockSave(dataService, 'update'); };
-		dataService.mockCreate = (): Sinon.SinonSpy => { return this.baseMockSave(dataService, 'create'); };
+		dataService.mockUpdate = (dataTransform?: IDataTransform): Sinon.SinonSpy => { return this.baseMockSave(dataService, 'update', dataTransform); };
+		dataService.mockCreate = (dataTransform?: IDataTransform): Sinon.SinonSpy => { return this.baseMockSave(dataService, 'create', dataTransform); };
 		dataService = this.updateResource(dataService, resource);
 		return dataService;
 	}
@@ -155,8 +155,8 @@ export class ContractLibrary implements IContractLibrary {
 		dataService.mockGetList = (data: any[]): Sinon.SinonSpy => { return this.baseMockGet(dataService, 'getList', data); };
 		dataService.mockGetDetail = (data: any): Sinon.SinonSpy => { return this.baseMockGet(dataService, 'get', data); };
 		dataService.mockChild = (mockCallback: { (children: any): void }): void => { return this.mockChild(dataService, mockCallback); };
-		dataService.mockUpdate = (): Sinon.SinonSpy => { return this.baseMockSave(dataService, 'update'); };
-		dataService.mockCreate = (): Sinon.SinonSpy => { return this.baseMockSave(dataService, 'create'); };
+		dataService.mockUpdate = (dataTransform?: IDataTransform): Sinon.SinonSpy => { return this.baseMockSave(dataService, 'update', dataTransform); };
+		dataService.mockCreate = (dataTransform?: IDataTransform): Sinon.SinonSpy => { return this.baseMockSave(dataService, 'create', dataTransform); };
 		dataService = this.updateResource(dataService, resource);
 		return dataService;
 	}
@@ -164,7 +164,7 @@ export class ContractLibrary implements IContractLibrary {
 	createMockSingleton(resource?: any): ISingletonDataServiceMock<any> {
 		let dataService: ISingletonDataServiceMock<any> = <any>this.builder.createSingletonResource({});
 		dataService.mockGet = (data: any): Sinon.SinonSpy => { return this.baseMockGet(dataService, 'get', data); };
-		dataService.mockUpdate = (): Sinon.SinonSpy => { return this.baseMockSave(dataService, 'update'); };
+		dataService.mockUpdate = (dataTransform?: IDataTransform): Sinon.SinonSpy => { return this.baseMockSave(dataService, 'update', dataTransform); };
 		dataService = this.updateResource(dataService, resource);
 		return dataService;
 	}
@@ -184,8 +184,11 @@ export class ContractLibrary implements IContractLibrary {
 		return func;
 	}
 
-	private baseMockSave(resource: any, actionName: string): Sinon.SinonSpy {
+	private baseMockSave(resource: any, actionName: string, dataTransform: IDataTransform): Sinon.SinonSpy {
 		let func: Sinon.SinonSpy = this.sinon.spy((data: any): any => {
+			if (dataTransform) {
+				data = dataTransform(data);
+			}
 			return this.$q.when(data);
 		});
 		resource[actionName] = func;

--- a/source/services/dataContracts/contractLibrary/dataServiceMocks.ts
+++ b/source/services/dataContracts/contractLibrary/dataServiceMocks.ts
@@ -6,11 +6,15 @@ import { IDataService, IBaseDomainObject } from '../dataService/data.service';
 import { IParentDataService } from '../dataService/parent/parentData.service';
 import { ISingletonDataService } from '../singletonDataService/singletonData.service';
 
+export interface IDataTransform {
+	(data: any): any;
+}
+
 export interface IDataServiceMock<TDataType extends IBaseDomainObject, TSearchParams> extends IDataService<TDataType, TSearchParams> {
 	mockGetList(data: any[]): Sinon.SinonSpy;
 	mockGetDetail(data: any): Sinon.SinonSpy;
-	mockUpdate(): Sinon.SinonSpy;
-	mockCreate(): Sinon.SinonSpy;
+	mockUpdate(dataTransform?: IDataTransform): Sinon.SinonSpy;
+	mockCreate(dataTransform?: IDataTransform): Sinon.SinonSpy;
 }
 
 // deprecated - use IDataServiceMock
@@ -20,8 +24,8 @@ export interface IParentDataServiceMock<TDataType extends IBaseDomainObject, TSe
 	mockGetList(data: any[]): Sinon.SinonSpy;
 	mockGetDetail(data: any): Sinon.SinonSpy;
 	mockChild(mockCallback: { (children: any): void }): void;
-	mockUpdate(): Sinon.SinonSpy;
-	mockCreate(): Sinon.SinonSpy;
+	mockUpdate(dataTransform?: IDataTransform): Sinon.SinonSpy;
+	mockCreate(dataTransform?: IDataTransform): Sinon.SinonSpy;
 }
 
 // deprecated - use IParentDataServiceMock
@@ -29,7 +33,7 @@ export interface IBaseParentDataServiceMock<TDataType extends IBaseDomainObject,
 
 export interface ISingletonDataServiceMock<TDataType> extends ISingletonDataService<TDataType> {
 	mockGet(data: any): Sinon.SinonSpy;
-	mockUpdate(): Sinon.SinonSpy;
+	mockUpdate(dataTransform?: IDataTransform): Sinon.SinonSpy;
 }
 
 // deprecated - use ISingletonDataServiceMock


### PR DESCRIPTION
…action. This allows the consumer to mock any transformations that would normally get applied on the server.
