### PR TITLE
Handle nulls for tokenized search

### DIFF
--- a/source/services/search/search.service.tests.ts
+++ b/source/services/search/search.service.tests.ts
@@ -117,5 +117,12 @@ describe('search utility', () => {
 			expect(searchUtility.tokenizedSearch(objectWithNesting, searchText)).to.be.true;
 			expect(searchUtility.tokenizedSearch(object2, searchText)).to.be.false;
 		});
+
+		it('should handle a null search', (): void => {
+			let object: ITestObject = {
+				prop: 'some values ended up with text',
+			};
+			expect(searchUtility.tokenizedSearch(object, null)).to.be.true;
+		});
 	});
 });

--- a/source/services/search/search.service.ts
+++ b/source/services/search/search.service.ts
@@ -32,6 +32,10 @@ class SearchUtility implements ISearchUtility {
 	}
 
 	tokenizedSearch(object: any, search: string, caseSensitive?: boolean): boolean {
+		if (search == null) {
+			return true;
+		}
+
 		return _.every(search.split(' '), (subsearch: string): boolean => {
 			return this.search(object, subsearch, caseSensitive);
 		});


### PR DESCRIPTION
Need a null check for the search value in tokenized search. Otherwise it breaks on `search.split`
