### PR TITLE
Default the params to an empty string

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-angular-utilities",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "Typescript utility classes published as angular services",
   "author": "Renovo Development Team",
   "main": "source/main.js",

--- a/source/services/http/http.service.tests.ts
+++ b/source/services/http/http.service.tests.ts
@@ -53,7 +53,7 @@ describe('HttpUtility', (): void => {
 	});
 
 	it('should parse the response from json', (): void => {
-		const putStream: Subject = new Subject();
+		const putStream: Subject<any> = new Subject();
 		const response: any = {
 			_body: 'content',
 			json: sinon.spy(),
@@ -67,7 +67,7 @@ describe('HttpUtility', (): void => {
 	});
 
 	it('should not try to parse if the response is empty', (): void => {
-		const putStream: Subject = new Subject();
+		const putStream: Subject<any> = new Subject();
 		const response: any = {
 			_body: '',
 			json: sinon.spy(),

--- a/source/services/http/http.service.tests.ts
+++ b/source/services/http/http.service.tests.ts
@@ -1,0 +1,82 @@
+import { URLSearchParams } from '@angular/http';
+import { Subject } from 'rxjs';
+
+import { objectUtility } from '../object/object.service';
+
+import { HttpUtility } from './http.service';
+
+interface IMockHttp {
+	get: Sinon.SinonSpy;
+	post: Sinon.SinonSpy;
+	put: Sinon.SinonSpy;
+	delete: Sinon.SinonSpy;
+}
+
+interface IMockInterceptor {
+	handleSuccess: Sinon.SinonSpy;
+	handleError: Sinon.SinonSpy;
+}
+
+describe('HttpUtility', (): void => {
+	let http: HttpUtility;
+	let mockHttpImplementation: IMockHttp;
+	let interceptor: IMockInterceptor;
+
+	beforeEach((): void => {
+		mockHttpImplementation = {
+			get: sinon.spy(() => new Subject()),
+			post: sinon.spy(() => new Subject()),
+			put: sinon.spy(() => new Subject()),
+			delete: sinon.spy(() => new Subject()),
+		};
+
+		interceptor = {
+			handleSuccess: sinon.spy(value => value),
+			handleError: sinon.spy(error => error),
+		};
+
+		http = new HttpUtility(<any>mockHttpImplementation, objectUtility, interceptor);
+	});
+
+	it('should default to an empty string for null or undefined parameters', (): void => {
+		const params: any = {
+			nullParam: null,
+			undefinedParam: undefined,
+		};
+
+		http.get('/test', params);
+
+		sinon.assert.calledOnce(mockHttpImplementation.get);
+		const args: any = mockHttpImplementation.get.firstCall.args;
+		expect(args[0]).to.equal('/test');
+		expect(args[1].search.toString()).to.equal('nullParam=&undefinedParam=');
+	});
+
+	it('should parse the response from json', (): void => {
+		const putStream: Subject = new Subject();
+		const response: any = {
+			_body: 'content',
+			json: sinon.spy(),
+		};
+		mockHttpImplementation.put = sinon.spy(() => putStream);
+
+		http.put('/test', {}).subscribe();
+		putStream.next(response);
+
+		sinon.assert.calledOnce(response.json);
+	});
+
+	it('should not try to parse if the response is empty', (): void => {
+		const putStream: Subject = new Subject();
+		const response: any = {
+			_body: '',
+			json: sinon.spy(),
+		};
+		mockHttpImplementation.put = sinon.spy(() => putStream);
+
+		http.put('/test', {}).subscribe();
+		putStream.next(response);
+
+		sinon.assert.notCalled(response.json);
+	});
+});

--- a/source/services/http/http.service.ts
+++ b/source/services/http/http.service.ts
@@ -37,7 +37,7 @@ export class HttpUtility implements IHttpUtility {
 	buildQueryString(params: any): URLSearchParams {
 		const searchParams: URLSearchParams = new URLSearchParams();
 		_.each(params, (param: any, key: string): void => {
-			searchParams.set(key, param);
+			searchParams.set(key, param || '');
 		});
 		return searchParams;
 	}

--- a/source/services/http/http.service.ts
+++ b/source/services/http/http.service.ts
@@ -6,6 +6,7 @@ import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/operator/map';
 
 import { errorHandlerToken, IErrorHandlerService } from '../errorHandler/errorHandler.service';
+import { objectToken, IObjectUtility } from '../object/object.service';
 
 export const interceptorToken: OpaqueToken = new OpaqueToken('Custom interceptor for http requests');
 
@@ -26,11 +27,14 @@ export interface IHttpUtility {
 @Injectable()
 export class HttpUtility implements IHttpUtility {
 	private http: Http;
+	private object: IObjectUtility;
 	private interceptor: IHttpInterceptor;
 
 	constructor( @Inject(Http) http: Http
+			, @Inject(objectToken) object: IObjectUtility
 			, @Optional() @Inject(interceptorToken) interceptor: IHttpInterceptor) {
 		this.http = http;
+		this.object = object;
 		this.interceptor = this.setDefaults(interceptor);
 	}
 
@@ -46,7 +50,7 @@ export class HttpUtility implements IHttpUtility {
 		return this.http.get(endpoint, { search: this.buildQueryString(params) })
 			.catch(this.handleError.bind(this))
 			.map(this.handleSuccess.bind(this))
-			.map((response: Response): TDataType => response.json());
+			.map((response: Response): TDataType => this.parse(response));
 	}
 
 	post<TDataType>(endpoint: string, data: any): Observable<TDataType> {
@@ -58,7 +62,7 @@ export class HttpUtility implements IHttpUtility {
 		return this.http.post(endpoint, JSON.stringify(data), options)
 			.catch(this.handleError.bind(this))
 			.map(this.handleSuccess.bind(this))
-			.map((response: Response) => response.json());
+			.map((response: Response) => this.parse(response));
 	}
 
 	put<TDataType>(endpoint: string, data: any): Observable<TDataType> {
@@ -70,7 +74,7 @@ export class HttpUtility implements IHttpUtility {
 		return this.http.put(endpoint, JSON.stringify(data), options)
 			.catch(this.handleError.bind(this))
 			.map(this.handleSuccess.bind(this))
-			.map((response: Response) => response.json());
+			.map((response: Response) => this.parse(response));
 	}
 
 	delete(endpoint: string, params?: any): Observable<void> {
@@ -78,6 +82,12 @@ export class HttpUtility implements IHttpUtility {
 			.catch(this.handleError.bind(this))
 			.map(this.handleSuccess.bind(this))
 			.map(() => null);
+	}
+
+	private parse(response: any): any {
+		return this.object.isNullOrEmpty(response._body)
+			? response.json()
+			: null;
 	}
 
 	private handleError(response: Response): Observable<any> {

--- a/source/services/http/http.service.ts
+++ b/source/services/http/http.service.ts
@@ -86,8 +86,8 @@ export class HttpUtility implements IHttpUtility {
 
 	private parse(response: any): any {
 		return this.object.isNullOrEmpty(response._body)
-			? response.json()
-			: null;
+			? null
+			: response.json();
 	}
 
 	private handleError(response: Response): Observable<any> {


### PR DESCRIPTION
Otherwise 'null' or 'undefined' gets sent to the server as a literal string. This is causing certain requests to break unexpectedly.
