### PR TITLE
Open to target '_self' if newTab is not true

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-angular-utilities",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "description": "Typescript utility classes published as angular services",
   "author": "Renovo Development Team",
   "main": "source/main.js",

--- a/source/services/redirect/redirect.service.tests.ts
+++ b/source/services/redirect/redirect.service.tests.ts
@@ -52,7 +52,7 @@ describe('RedirectService', () => {
 			redirectService.to('/some/path');
 
 			sinon.assert.calledOnce(mockWindow.open);
-			sinon.assert.calledWith(mockWindow.open, '/some/path');
+			sinon.assert.calledWith(mockWindow.open, '/some/path', '_self');
 		});
 
 		it('should redirect to the specified target in new window', () => {

--- a/source/services/redirect/redirect.service.ts
+++ b/source/services/redirect/redirect.service.ts
@@ -25,7 +25,7 @@ export class RedirectService implements IRedirectService {
 
 	to(target: string, newTab?: boolean): void {
 		if (!newTab) {
-			this.window.open(target);
+			this.window.open(target, '_self');
 		} else {
 			const win: Window = this.window.open(target, '_blank');
 			win.focus();


### PR DESCRIPTION
Apparently window.open opens to a new tab by default. We actually want to open to the same tab unless newTab is true.
