### PR TITLE
Timeout service

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-angular-utilities",
-  "version": "3.1.5",
+  "version": "3.1.6",
   "description": "Typescript utility classes published as angular services",
   "author": "Renovo Development Team",
   "main": "source/main.js",

--- a/source/services/services.module.ts
+++ b/source/services/services.module.ts
@@ -21,6 +21,7 @@ import * as stringService from './string/string.service';
 import * as synchronizedRequests from './synchronizedRequests/synchronizedRequests.service';
 import * as test from './test/test.module';
 import * as time from './time/time.service';
+import * as timeout from './timeout/timeout.service';
 import * as timezone from './timezone/timezone.service';
 import * as transform from './transform/transform.service';
 import * as validation from './validation/validation.service';
@@ -48,6 +49,7 @@ export {
 	synchronizedRequests,
 	test,
 	time,
+	timeout,
 	timezone,
 	transform,
 	validation,
@@ -56,7 +58,7 @@ export {
 /**
  * Providers for utility services.
  */
-export const UTILITY_PROVIDERS: (Provider | Provider[])[] = [
+export const UTILITY_PROVIDERS: (Provider | Provider[] | any)[] = [
 	HTTP_PROVIDERS,
 
 	array.ARRAY_PROVIDER,
@@ -73,6 +75,7 @@ export const UTILITY_PROVIDERS: (Provider | Provider[])[] = [
 	stringService.STRING_PROVIDER,
 	synchronizedRequests.SYNCHRONIZED_REQUESTS_PROVIDER,
 	time.TIME_PROVIDER,
+	timeout.TimeoutService,
 	timezone.TIMEZONE_PROVIDER,
 	transform.TRANSFORM_PROVIDER,
 

--- a/source/services/timeout/timeout.service.tests.ts
+++ b/source/services/timeout/timeout.service.tests.ts
@@ -1,0 +1,41 @@
+import { TimeoutService, ITimeout } from './timeout.service';
+
+import { fakeAsync, tick, flushMicrotasks } from '../test/fakeAsync';
+
+describe('TimeoutService', (): void => {
+	let timeoutService: TimeoutService;
+
+	beforeEach(() => {
+		timeoutService = new TimeoutService();
+	});
+
+	it('should resolve the promise and call the callback when the timeout finishes', fakeAsync((): void => {
+		const promiseSpy: Sinon.SinonSpy = sinon.spy();
+		const callback: Sinon.SinonSpy = sinon.spy();
+
+		timeoutService.setTimeout(callback, 2000).then(promiseSpy);
+
+		tick(2000);
+		flushMicrotasks();
+
+		sinon.assert.calledOnce(promiseSpy);
+		sinon.assert.calledOnce(callback);
+	}));
+
+	it('should reject the promise without calling the callback if the timeout is canceled', fakeAsync((): void => {
+		const rejectSpy: Sinon.SinonSpy = sinon.spy();
+		const callback: Sinon.SinonSpy = sinon.spy();
+
+		const timeout: ITimeout = timeoutService.setTimeout(callback, 2000);
+
+		timeout.then(assert.fail)
+				.catch(rejectSpy);
+
+		timeout.cancel();
+		tick(2000);
+		flushMicrotasks();
+
+		sinon.assert.calledOnce(rejectSpy);
+		sinon.assert.notCalled(callback);
+	}));
+});

--- a/source/services/timeout/timeout.service.tests.ts
+++ b/source/services/timeout/timeout.service.tests.ts
@@ -26,10 +26,9 @@ describe('TimeoutService', (): void => {
 		const rejectSpy: Sinon.SinonSpy = sinon.spy();
 		const callback: Sinon.SinonSpy = sinon.spy();
 
-		const timeout: ITimeout = timeoutService.setTimeout(callback, 2000);
-
-		timeout.then(assert.fail)
-				.catch(rejectSpy);
+		const timeout: ITimeout = timeoutService.setTimeout(callback, 2000)
+												.then(assert.fail)
+												.catch(rejectSpy);
 
 		timeout.cancel();
 		tick(2000);

--- a/source/services/timeout/timeout.service.tests.ts
+++ b/source/services/timeout/timeout.service.tests.ts
@@ -38,4 +38,18 @@ describe('TimeoutService', (): void => {
 		sinon.assert.calledOnce(rejectSpy);
 		sinon.assert.notCalled(callback);
 	}));
+
+	it('should allow for specifying just a duration for chaining as a promise', fakeAsync((): void => {
+		const promiseSpy: Sinon.SinonSpy = sinon.spy();
+
+		timeoutService.setTimeout(2000).then(promiseSpy);
+
+		flushMicrotasks();
+		sinon.assert.notCalled(promiseSpy);
+
+		tick(2000);
+		flushMicrotasks();
+
+		sinon.assert.calledOnce(promiseSpy);
+	}));
 });

--- a/source/services/timeout/timeout.service.ts
+++ b/source/services/timeout/timeout.service.ts
@@ -1,0 +1,27 @@
+export interface ITimeout extends Promise<void> {
+	cancel(): void;
+}
+
+export class TimeoutService {
+	setTimeout(callback: Function, duration?: number): ITimeout {
+		let pending: boolean;
+		let rejectFunc: Function;
+		const timeout: ITimeout = <any>new Promise<void>((resolve, reject) => {
+			pending = true;
+			rejectFunc = reject;
+
+			setTimeout(() => {
+				if (pending) {
+					pending = false;
+					resolve();
+					callback();
+				}
+			}, duration);
+		});
+		timeout.cancel = () => {
+			pending = false;
+			rejectFunc();
+		};
+		return timeout;
+	}
+}

--- a/source/services/timeout/timeout.service.ts
+++ b/source/services/timeout/timeout.service.ts
@@ -1,9 +1,17 @@
+import { isFunction } from 'lodash';
+
 export interface ITimeout extends Promise<void> {
 	cancel(): void;
 }
 
 export class TimeoutService {
-	setTimeout(callback: Function, duration?: number): ITimeout {
+	setTimeout(callbackOrDuration: number): ITimeout;
+	setTimeout(callbackOrDuration: Function, duration?: number): ITimeout;
+	setTimeout(callbackOrDuration: Function | number, duration?: number): ITimeout {
+		let useCallback = isFunction(callbackOrDuration);
+		let callback: Function = useCallback ? <any>callbackOrDuration : () => null;
+		duration = useCallback ? duration : <any>callbackOrDuration;
+
 		let pending: boolean;
 		let rejectFunc: Function;
 		const timeout: ITimeout = <any>new Promise<void>((resolve, reject) => {

--- a/source/utilitiesDowngrade.ts
+++ b/source/utilitiesDowngrade.ts
@@ -24,6 +24,7 @@ import { REDIRECT_PROVIDER, redirectToken } from './services/redirect/redirect.s
 import { STRING_PROVIDER, stringToken } from './services/string/string.service';
 import { SYNCHRONIZED_REQUESTS_PROVIDER, synchronizedRequestsToken } from './services/synchronizedRequests/synchronizedRequests.service';
 import { TIME_PROVIDER, timeToken } from './services/time/time.service';
+import { TimeoutService } from './services/timeout/timeout.service';
 import { TIMEZONE_PROVIDER, timezoneToken } from './services/timezone/timezone.service';
 import { TRANSFORM_PROVIDER, transformToken } from './services/transform/transform.service';
 import { VALIDATION_PROVIDER, validationToken } from './services/validation/validation.service';
@@ -47,6 +48,7 @@ export const observableServiceName: string = 'rlObservableService';
 export const stringServiceName: string = 'rlStringService';
 export const synchronizedRequestsServiceName: string = 'rlSynchronizedRequestsService';
 export const timeServiceName: string = 'rlTimeService';
+export const timeoutServiceName: string = 'rlTimeoutService';
 export const timezoneServiceName: string = 'rlTimezoneService';
 export const transformServiceName: string = 'rlTransformService';
 export const validationServiceName: string = 'rlValidationService';
@@ -96,6 +98,7 @@ export function downgradeUtilitiesToAngular1(upgradeAdapter: UpgradeAdapter) {
 	upgradeAdapter.addProvider(STRING_PROVIDER);
 	upgradeAdapter.addProvider(SYNCHRONIZED_REQUESTS_PROVIDER);
 	upgradeAdapter.addProvider(TIME_PROVIDER);
+	upgradeAdapter.addProvider(TimeoutService);
 	upgradeAdapter.addProvider(TIMEZONE_PROVIDER);
 	upgradeAdapter.addProvider(TRANSFORM_PROVIDER);
 	upgradeAdapter.addProvider(VALIDATION_PROVIDER);
@@ -119,6 +122,7 @@ export function downgradeUtilitiesToAngular1(upgradeAdapter: UpgradeAdapter) {
 	utilitiesModule.factory(stringServiceName, upgradeAdapter.downgradeNg2Provider(stringToken));
 	utilitiesModule.factory(synchronizedRequestsServiceName, upgradeAdapter.downgradeNg2Provider(synchronizedRequestsToken));
 	utilitiesModule.factory(timeServiceName, upgradeAdapter.downgradeNg2Provider(timeToken));
+	utilitiesModule.factory(timeoutServiceName, upgradeAdapter.downgradeNg2Provider(TimeoutService));
 	utilitiesModule.factory(timezoneServiceName, upgradeAdapter.downgradeNg2Provider(timezoneToken));
 	utilitiesModule.factory(transformServiceName, upgradeAdapter.downgradeNg2Provider(transformToken));
 	utilitiesModule.factory(validationServiceName, upgradeAdapter.downgradeNg2Provider(validationToken));


### PR DESCRIPTION
Created a service for representing timeouts as a promise. This is useful in cases where you want to 'cancel' a timeout, such as for long click buttons.
