### PR TITLE
When nulls come from the server, leave them as null

### DIFF
--- a/source/services/dataContracts/converters/timeConverter/timeConverter.tests.ts
+++ b/source/services/dataContracts/converters/timeConverter/timeConverter.tests.ts
@@ -18,6 +18,7 @@ describe('timeConverter', (): void => {
 	});
 
 	it('should handle nulls', (): void => {
+		expect(timeConverter.fromServer(null)).to.be.null;
 		expect(timeConverter.toServer(null)).to.be.null;
 	});
 });

--- a/source/services/dataContracts/converters/timeConverter/timeConverter.ts
+++ b/source/services/dataContracts/converters/timeConverter/timeConverter.ts
@@ -10,7 +10,9 @@ export { defaultFormats };
 
 export let timeConverter: IConverter<moment.Moment> = {
 	fromServer(raw: string): moment.Moment {
-		return timezoneService.buildMomentWithTimezone(raw, timezoneService.currentTimezone, defaultFormats.timeFormat);
+		return raw != null
+			? timezoneService.buildMomentWithTimezone(raw, timezoneService.currentTimezone, defaultFormats.timeFormat)
+			: null;
 	},
 	toServer(data: moment.Moment): string {
 		return data != null


### PR DESCRIPTION
Otherwise moment will build a moment object marked as 'invalid date'
