### PR TITLE
Create HttpDigestService

### DIFF
--- a/source/services/http/httpDigest.service.tests.ts
+++ b/source/services/http/httpDigest.service.tests.ts
@@ -1,0 +1,22 @@
+import {HttpDigestService} from './httpDigest.service';
+
+describe('HttpDigestService', (): void => {
+	it('should call the passed in function', (): void => {
+        const httpDigestService = new HttpDigestService();
+        const functionToCall = sinon.spy();
+
+        httpDigestService.startDigestCycle(functionToCall);
+
+        sinon.assert.calledOnce(functionToCall);
+    });
+
+	it('should not call the passed in function if null', (): void => {
+        const httpDigestService = new HttpDigestService();
+        const functionToNotCall = null;
+        const functionSpy = sinon.spy(functionToNotCall);
+
+        httpDigestService.startDigestCycle(functionToNotCall);
+
+        sinon.assert.notCalled(functionSpy);
+	});
+});

--- a/source/services/http/httpDigest.service.ts
+++ b/source/services/http/httpDigest.service.ts
@@ -1,0 +1,26 @@
+import { Injectable, Provider, OpaqueToken } from '@angular/core';
+
+
+export interface IHttpDigestService {
+	startDigestCycle($digest: Function): void;
+}
+
+
+@Injectable()
+export class HttpDigestService implements IHttpDigestService {
+
+    constructor() { }
+
+    startDigestCycle(digest: Function): void {
+        if (digest != null) {
+            digest();
+        }
+    }
+
+}
+
+export const httpDigestToken: OpaqueToken = new OpaqueToken('A service for initiating a new digests cycle after http calls');
+
+export const HTTP_DIGEST_PROVIDER: Provider = new Provider(httpDigestToken, {
+	useClass: HttpDigestService,
+});

--- a/source/services/services.module.ts
+++ b/source/services/services.module.ts
@@ -10,6 +10,7 @@ import * as fileSize from './fileSize/fileSize.module';
 import * as genericSearchFilter from './genericSearchFilter/genericSearchFilter.service';
 import * as guid from './guid/guid.service';
 import * as http from './http/http.service';
+import * as httpDigestService from './http/httpDigest.service';
 import * as logger from './logger/logger.service';
 import * as notification from './notification/notification.service';
 import * as numberService from './number/number.service';
@@ -38,6 +39,7 @@ export {
 	genericSearchFilter,
 	guid,
 	http,
+	httpDigestService,
 	logger,
 	notification,
 	numberService as number,
@@ -69,6 +71,7 @@ export const UTILITY_PROVIDERS: (Provider | Provider[] | any)[] = [
 	genericSearchFilter.GENERIC_SEARCH_FILTER_PROVIDER,
 	guid.GUID_PROVIDER,
 	http.HTTP_PROVIDER,
+	httpDigestService.HTTP_DIGEST_PROVIDER,
 	numberService.NUMBER_PROVIDER,
 	objectService.OBJECT_PROVIDER,
 	search.SEARCH_PROVIDER,

--- a/source/utilitiesDowngrade.ts
+++ b/source/utilitiesDowngrade.ts
@@ -15,6 +15,7 @@ import { ERROR_HANDLER_PROVIDER, DEFAULT_ERROR_PROVIDERS, DEFAULT_LOGIN_URL_PROV
 import { GENERIC_SEARCH_FILTER_PROVIDER, genericSearchFilterToken } from './services/genericSearchFilter/genericSearchFilter.service';
 import { GUID_PROVIDER, guidToken } from './services/guid/guid.service';
 import { HTTP_PROVIDER, httpToken } from './services/http/http.service';
+import { HTTP_DIGEST_PROVIDER, httpDigestToken } from './services/http/httpDigest.service';
 import { LOGGER_PROVIDER, loggerToken } from './services/logger/logger.service';
 import { NOTIFICATION_PROVIDER, notificationToken } from './services/notification/notification.service';
 import { NUMBER_PROVIDER, numberToken } from './services/number/number.service';
@@ -38,6 +39,7 @@ export const booleanServiceName: string = 'rlBooleanService';
 export const resourceBuilderServiceName: string = 'rlResourceBuilderService';
 export const dateServiceName: string = 'rlDateService';
 export const errorHandlerServiceName: string = 'rlErrorHandlerService';
+export const httpDigestServiceName: string = 'rlHttpDigestService';
 export const genericSearchFilterServiceName: string = 'rlGenericSearchFilterService';
 export const guidServiceName: string = 'rlGuidService';
 export const httpServiceName: string = 'rlHttpService';
@@ -86,6 +88,7 @@ export function downgradeUtilitiesToAngular1(upgradeAdapter: UpgradeAdapter) {
 	upgradeAdapter.addProvider(DEFAULT_ERROR_PROVIDERS);
 	upgradeAdapter.addProvider(DEFAULT_LOGIN_URL_PROVIDERS);
 	upgradeAdapter.addProvider(ERROR_HANDLER_PROVIDER);
+	upgradeAdapter.addProvider(HTTP_DIGEST_PROVIDER);
 	upgradeAdapter.addProvider(GENERIC_SEARCH_FILTER_PROVIDER);
 	upgradeAdapter.addProvider(GUID_PROVIDER);
 	upgradeAdapter.addProvider(HTTP_PROVIDER);
@@ -112,6 +115,7 @@ export function downgradeUtilitiesToAngular1(upgradeAdapter: UpgradeAdapter) {
 	utilitiesModule.factory(resourceBuilderServiceName, upgradeAdapter.downgradeNg2Provider(resourceBuilderToken));
 	utilitiesModule.factory(dateServiceName, upgradeAdapter.downgradeNg2Provider(dateToken));
 	utilitiesModule.factory(errorHandlerServiceName, upgradeAdapter.downgradeNg2Provider(errorHandlerToken));
+	utilitiesModule.factory(httpDigestServiceName, upgradeAdapter.downgradeNg2Provider(httpDigestToken));
 	utilitiesModule.factory(genericSearchFilterServiceName, upgradeAdapter.downgradeNg2Provider(genericSearchFilterToken));
 	utilitiesModule.factory(guidServiceName, upgradeAdapter.downgradeNg2Provider(guidToken));
 	utilitiesModule.factory(httpServiceName, upgradeAdapter.downgradeNg2Provider(httpToken));


### PR DESCRIPTION
HTTP requests were using the ng2 http module, which returns an observable and was being converted to a promise.  Because of this, the digest cycle was not firing and elements in the DOM were not updating.

Created an ng2 HTTP interceptor service that will explicitly run a digest cycle after HTTP requests succeed or fail.  Because scope does not exist in ng2, the interceptor was designed to accept scope.applyAsync as a parameter and call it.

Resolves issue: https://renovo.myjetbrains.com/youtrack/issue/MUSIC-700

Paired with @TheOriginalJosh 
