### PR TITLE
Make isEmpty impure

### DIFF
--- a/source/filters/isEmpty/isEmpty.ts
+++ b/source/filters/isEmpty/isEmpty.ts
@@ -1,11 +1,14 @@
-import {Inject, Pipe, PipeTransform} from '@angular/core';
+import { Inject, Pipe, PipeTransform } from '@angular/core';
 
 import {
 	IObjectUtility,
 	objectToken
 } from '../../services/object/object.service';
 
-@Pipe({	name: 'isEmpty' })
+@Pipe({
+	name: 'isEmpty',
+	pure: false,
+})
 export class IsEmptyPipe implements PipeTransform {
 	private objectUtility: IObjectUtility;
 


### PR DESCRIPTION
The concept of a 'pure' pipe is one in which the output only changes if the input changes. Apparently, this is affected by the mutable/immutable question. A pure pipe will only update if the reference of its dependency changes, and thus is broken by mutability. By setting the pipe to impure, it picks up changes properly with mutable data structures.
