### PR TITLE
Allow for using data contract mocks outside of a fake async test zone

### DIFF
--- a/source/services/test/fakeAsync.ts
+++ b/source/services/test/fakeAsync.ts
@@ -103,3 +103,7 @@ export function flushMicrotasks(): void {
 export function queueRequest(request): void {
 	requestQueue.push(request);
 }
+
+export function inTestZone(): boolean {
+	return !!Zone.current.get('FakeAsyncTestZoneSpec');
+}


### PR DESCRIPTION
Defaults to a behavior subject (returns data immediately). This will allow use to use this technique for mocking requests in prototyping our application instead of using json mocks. json mocks get out of date really fast and end up building cruft in our application bundles.
