### PR TITLE
Added a helper for mocking data contracts - alternative approach

### DIFF
--- a/source/services/dataContracts/dataService/data.service.ts
+++ b/source/services/dataContracts/dataService/data.service.ts
@@ -20,6 +20,8 @@ export interface IDataService<TDataType extends IBaseDomainObject, TSearchParams
 	delete(domainObject: TDataType): Observable<void>;
 	version(versionNumber: number): DataService<TDataType, TSearchParams>;
 
+	mockResource(mockData: TDataType[]): void;
+
 	useMock: boolean;
 	logRequests: boolean;
 }
@@ -130,6 +132,11 @@ export class DataService<TDataType extends IBaseDomainObject, TSearchParams> imp
 		let dataService: DataService<TDataType, TSearchParams> = _.clone(this);
 		dataService.url = helper.versionEndpoint(dataService.url, versionNumber);
 		return dataService;
+	}
+
+	mockResource(mockData: TDataType[]): void {
+		this.mockData = mockData;
+		this.useMock = true;
 	}
 }
 

--- a/source/services/dataContracts/singletonDataService/singletonData.service.ts
+++ b/source/services/dataContracts/singletonDataService/singletonData.service.ts
@@ -12,6 +12,8 @@ export interface ISingletonDataService<TDataType> {
 	update(domainObject: TDataType): Observable<TDataType>;
 	version(versionNumber: number): SingletonDataService<TDataType>;
 
+	mockResource(mockData: TDataType): void;
+
 	useMock: boolean;
 	logRequests: boolean;
 }
@@ -59,6 +61,11 @@ export class SingletonDataService<TDataType> implements ISingletonDataService<TD
 		let dataService: SingletonDataService<TDataType> = _.clone(this);
 		dataService.url = helper.versionEndpoint(dataService.url, versionNumber);
 		return dataService;
+	}
+
+	mockResource(mockData: TDataType): void {
+		this.mockData = mockData;
+		this.useMock = true;
 	}
 }
 


### PR DESCRIPTION
Instead of taking the approach of allowing application code to create and use mock contracts, we'll simply provide a helper function that sets the mock data on the contract and specifies that useMock should be true. This still allows the application to pull the mock data out of the contract definition and into the prototype application code, while also still integrating with the logging capabilities built into data contracts. The only drawback to this approach is that a data contract, once set to use mocks, will use mocks everywhere it is used, unless it is first cloned.
