### PR TITLE
Rxjs testing

### DIFF
--- a/source/services/dataContracts/baseDataServiceBehavior.tests.ts
+++ b/source/services/dataContracts/baseDataServiceBehavior.tests.ts
@@ -5,7 +5,7 @@ import { BaseDataServiceBehavior, ISearchResult } from './baseDataServiceBehavio
 import { arrayUtility } from '../array/array.service';
 import { IHttpUtility } from '../http/http.service';
 
-import { IMockedRequest, mock, fakeAsync } from '../test/index';
+import { IMockedRequest, mock, rlFakeAsync } from '../test/index';
 
 interface ITestMock {
 	id?: number;
@@ -45,7 +45,7 @@ describe('base data service behavior', () => {
 			dataServiceBehavior = new BaseDataServiceBehavior<ITestMock>(mockHttp, null);
 		});
 
-		it('should make an http request to get a list of data', fakeAsync((): void => {
+		it('should make an http request to get a list of data', rlFakeAsync((): void => {
 			const mockList: ITestMock[] = [
 				{ id: 1 },
 				{ id: 2 },
@@ -78,7 +78,7 @@ describe('base data service behavior', () => {
 			mockGet.flush();
 		}));
 
-		it('should make a POST request to search the data', fakeAsync((): void => {
+		it('should make a POST request to search the data', rlFakeAsync((): void => {
 			const mockList: ITestMock[] = [
 				{ id: 1 },
 				{ id: 2 },
@@ -116,7 +116,7 @@ describe('base data service behavior', () => {
 			mockPost.flush();
 		}));
 
-		it('should make an http request to get a domain object', fakeAsync((): void => {
+		it('should make an http request to get a domain object', rlFakeAsync((): void => {
 			const id: number = 1;
 			const mockItem: ITestMock = { id: id };
 
@@ -138,7 +138,7 @@ describe('base data service behavior', () => {
 			mockGet.flush();
 		}));
 
-		it('should make an http request to create a domain object', fakeAsync((): void => {
+		it('should make an http request to create a domain object', rlFakeAsync((): void => {
 			const mockItem: ITestMock = { id: 1 };
 
 			const mockPost: IMockedRequest<ITestMock> = mock.request(mockItem);
@@ -160,7 +160,7 @@ describe('base data service behavior', () => {
 			mockPost.flush();
 		}));
 
-		it('should make an http request to save an existing domain object', fakeAsync((): void => {
+		it('should make an http request to save an existing domain object', rlFakeAsync((): void => {
 			const mockItem: ITestMock = { id: 1 };
 
 			const mockPut: IMockedRequest<ITestMock> = mock.request(mockItem);
@@ -182,7 +182,7 @@ describe('base data service behavior', () => {
 			mockPut.flush();
 		}));
 
-		it('should make an http request to delete an existing domain object', fakeAsync((): void => {
+		it('should make an http request to delete an existing domain object', rlFakeAsync((): void => {
 			const mockItem: ITestMock = { id: 1 };
 
 			const mockDelete: IMockedRequest<void> = mock.request();

--- a/source/services/synchronizedRequests/synchronizedRequests.service.tests.ts
+++ b/source/services/synchronizedRequests/synchronizedRequests.service.tests.ts
@@ -1,11 +1,11 @@
 import { mock, IMockedPromise } from '../test/mockAsync';
 import { SynchronizedRequestsService } from './synchronizedRequests.service';
-import { fakeAsync } from '../test/fakeAsync';
+import { rlFakeAsync } from '../test/fakeAsync';
 
 describe('synchronizedRequests', () => {
 	let synchronizedRequests: SynchronizedRequestsService;
 
-	it('should accept the results from only the most recent request', fakeAsync((): void => {
+	it('should accept the results from only the most recent request', rlFakeAsync((): void => {
 		const firstRequestData: number[] = [1, 2];
 		const secondRequestData: number[] = [3, 4];
 		const firstRequest: IMockedPromise<number[]> = mock.promise(firstRequestData);

--- a/source/services/test/fakeAsync.tests.ts
+++ b/source/services/test/fakeAsync.tests.ts
@@ -1,6 +1,21 @@
+import { Subject } from 'rxjs';
 import { fakeAsync, tick, flushMicrotasks, queueRequest } from './fakeAsync';
 
 describe('fakeAsync', () => {
+	it('should schedule an rxjs action', fakeAsync(() => {
+		const testStream = new Subject<void>();
+		const testSpy = sinon.spy();
+		testStream.delay(1000).subscribe(() => testSpy());
+		testStream.next(null);
+
+		sinon.assert.notCalled(testSpy);
+
+		tick(1000);
+		flushMicrotasks();
+
+		sinon.assert.calledOnce(testSpy);
+	}));
+
 	it('should throw an error if there are pending requests', () => {
 		expect(fakeAsync(() => {
 			queueRequest({ pending: true });

--- a/source/services/test/fakeAsync.tests.ts
+++ b/source/services/test/fakeAsync.tests.ts
@@ -1,0 +1,15 @@
+import { fakeAsync, tick, flushMicrotasks, queueRequest } from './fakeAsync';
+
+describe('fakeAsync', () => {
+	it('should throw an error if there are pending requests', () => {
+		expect(fakeAsync(() => {
+			queueRequest({ pending: true });
+		})).to.throw('There are still pending requests. Please be sure to flush all of your requests');
+	});
+
+	it('should run successfully if all requests in the queue are resolved', () => {
+		fakeAsync(() => {
+			queueRequest({ pending: false });
+		})();
+	});
+});

--- a/source/services/test/fakeAsync.tests.ts
+++ b/source/services/test/fakeAsync.tests.ts
@@ -1,8 +1,8 @@
 import { Subject } from 'rxjs';
-import { fakeAsync, tick, flushMicrotasks, queueRequest } from './fakeAsync';
+import { rlFakeAsync, rlTick, flushMicrotasks, rlQueueRequest } from './fakeAsync';
 
 describe('fakeAsync', () => {
-	it('should schedule an rxjs action', fakeAsync(() => {
+	it('should schedule an rxjs action', rlFakeAsync(() => {
 		const testStream = new Subject<void>();
 		const testSpy = sinon.spy();
 		testStream.delay(1000).subscribe(() => testSpy());
@@ -10,21 +10,21 @@ describe('fakeAsync', () => {
 
 		sinon.assert.notCalled(testSpy);
 
-		tick(1000);
+		rlTick(1000);
 		flushMicrotasks();
 
 		sinon.assert.calledOnce(testSpy);
 	}));
 
 	it('should throw an error if there are pending requests', () => {
-		expect(fakeAsync(() => {
-			queueRequest({ pending: true });
+		expect(rlFakeAsync(() => {
+			rlQueueRequest({ pending: true });
 		})).to.throw('There are still pending requests. Please be sure to flush all of your requests');
 	});
 
 	it('should run successfully if all requests in the queue are resolved', () => {
-		fakeAsync(() => {
-			queueRequest({ pending: false });
+		rlFakeAsync(() => {
+			rlQueueRequest({ pending: false });
 		})();
 	});
 });

--- a/source/services/test/fakeAsync.ts
+++ b/source/services/test/fakeAsync.ts
@@ -1,7 +1,10 @@
-let requestQueue = [];
+import { Scheduler } from 'rxjs';
 
-import { fakeAsync as ngFakeAsync, flushMicrotasks } from '@angular/core/testing';
-export { flushMicrotasks, tick } from '@angular/core/testing';
+let requestQueue = [];
+let timeElapsed: number = 0;
+
+import { fakeAsync as ngFakeAsync, flushMicrotasks, tick as ngTick, discardPeriodicTasks } from '@angular/core/testing';
+export { flushMicrotasks };
 
 /**
  * Wraps angular fakeAsync with the ability to track pending requests
@@ -9,11 +12,15 @@ export { flushMicrotasks, tick } from '@angular/core/testing';
  * When a request is initiated using mockAsync, the request is pushed to the requestQueue
  * If there are any pending requests at the end of the function, an exception will be thrown.
  *
+ * Also overrides 'now' on the default rxjs scheduler to return a value based on how much time has elapsed via 'tick'
+ *
  * @param fn
  * @returns {Function} The function wrapped to be executed in the fakeAsync zone
  */
 export function fakeAsync(fn: Function): { (done?: MochaDone): void } {
 	return ngFakeAsync(function (...args) {
+		timeElapsed = 0;
+		Scheduler.async.now = () => timeElapsed;
 		requestQueue = [];
 		let res = fn(...args);
 		flushMicrotasks();
@@ -26,4 +33,9 @@ export function fakeAsync(fn: Function): { (done?: MochaDone): void } {
 
 export function queueRequest(request): void {
 	requestQueue.push(request);
+}
+
+export function tick(milliseconds: number) {
+	timeElapsed += milliseconds;
+	ngTick(milliseconds);
 }

--- a/source/services/test/fakeAsync.ts
+++ b/source/services/test/fakeAsync.ts
@@ -19,6 +19,7 @@ export { flushMicrotasks };
  */
 export function fakeAsync(fn: Function): { (done?: MochaDone): void } {
 	return ngFakeAsync(function (...args) {
+		const originalNow = Scheduler.async.now;
 		timeElapsed = 0;
 		Scheduler.async.now = () => timeElapsed;
 		requestQueue = [];
@@ -27,6 +28,7 @@ export function fakeAsync(fn: Function): { (done?: MochaDone): void } {
 		if (requestQueue.some(request => request.pending)) {
 			throw new Error('There are still pending requests. Please be sure to flush all of your requests');
 		}
+		Scheduler.async.now = originalNow;
 		return res;
 	});
 }

--- a/source/services/test/fakeAsync.ts
+++ b/source/services/test/fakeAsync.ts
@@ -3,7 +3,7 @@ import { Scheduler } from 'rxjs';
 let requestQueue = [];
 let timeElapsed: number = 0;
 
-import { fakeAsync as ngFakeAsync, flushMicrotasks, tick as ngTick, discardPeriodicTasks } from '@angular/core/testing';
+import { fakeAsync as ngFakeAsync, flushMicrotasks, tick as ngTick } from '@angular/core/testing';
 export { flushMicrotasks };
 
 /**
@@ -17,7 +17,7 @@ export { flushMicrotasks };
  * @param fn
  * @returns {Function} The function wrapped to be executed in the fakeAsync zone
  */
-export function fakeAsync(fn: Function): { (done?: MochaDone): void } {
+export function rlFakeAsync(fn: Function): { (done?: MochaDone): void } {
 	return ngFakeAsync(function (...args) {
 		const originalNow = Scheduler.async.now;
 		timeElapsed = 0;
@@ -33,11 +33,19 @@ export function fakeAsync(fn: Function): { (done?: MochaDone): void } {
 	});
 }
 
-export function queueRequest(request): void {
+
+export function rlQueueRequest(request): void {
 	requestQueue.push(request);
 }
 
-export function tick(milliseconds: number) {
+export function rlTick(milliseconds: number) {
 	timeElapsed += milliseconds;
 	ngTick(milliseconds);
 }
+
+// deprecated - use rlFakeAsync and rlTick instead
+export {
+	rlFakeAsync as fakeAsync,
+	rlTick as tick,
+	rlQueueRequest as queueRequest,
+};

--- a/source/services/test/mockAsync.tests.ts
+++ b/source/services/test/mockAsync.tests.ts
@@ -1,7 +1,6 @@
 import { Observable } from 'rxjs';
 
 import { mock, IMockedRequest } from './mockAsync';
-// import { fakeAsync } from '@angular/core/testing';
 import { fakeAsync } from './fakeAsync';
 
 interface ITestType {

--- a/source/services/test/mockAsync.tests.ts
+++ b/source/services/test/mockAsync.tests.ts
@@ -1,7 +1,7 @@
 import { Observable } from 'rxjs';
 
 import { mock, IMockedRequest } from './mockAsync';
-import { fakeAsync } from './fakeAsync';
+import { rlFakeAsync } from './fakeAsync';
 
 interface ITestType {
 	value: number;
@@ -13,7 +13,7 @@ interface ITestDataService {
 }
 
 describe('mockAsync', () => {
-	it('should create a request that resolves when flushed', fakeAsync(() => {
+	it('should create a request that resolves when flushed', rlFakeAsync(() => {
 		let mockedObservable: IMockedRequest<ITestType> = mock.request({ value: 10 });
 		mockedObservable()
 			.subscribe((result: ITestType) => {
@@ -23,7 +23,7 @@ describe('mockAsync', () => {
 		mockedObservable.flush();
 	}));
 
-	it('should create a request that resolves with dynamic content when flushed', fakeAsync(() => {
+	it('should create a request that resolves with dynamic content when flushed', rlFakeAsync(() => {
 		let mockedObservable: IMockedRequest<ITestType> = mock.request((value1: number, value2: number) => {
 			return { value: value1 + value2 };
 		});
@@ -36,7 +36,7 @@ describe('mockAsync', () => {
 		mockedObservable.flush();
 	}));
 
-	it('should create a request that is rejected', fakeAsync(() => {
+	it('should create a request that is rejected', rlFakeAsync(() => {
 		let mockedObservable: IMockedRequest<ITestType> = mock.rejectedRequest<ITestType>(new Error('an error'));
 
 		mockedObservable()
@@ -49,7 +49,7 @@ describe('mockAsync', () => {
 		mockedObservable.flush();
 	}));
 
-	it('should create a request and set it to be rejected', fakeAsync(() => {
+	it('should create a request and set it to be rejected', rlFakeAsync(() => {
 		let mockedObservable: IMockedRequest<ITestType> = mock.request<ITestType>({ value: 3 });
 		mockedObservable.reject(new Error('error message'));
 
@@ -63,7 +63,7 @@ describe('mockAsync', () => {
 		mockedObservable.flush();
 	}));
 
-	it('should be able to reuse mocked requests', fakeAsync(() => {
+	it('should be able to reuse mocked requests', rlFakeAsync(() => {
 		let mockedObservable: IMockedRequest<ITestType> = mock.request<ITestType>({ value: 3 }, true);
 
 		mockedObservable()
@@ -81,7 +81,7 @@ describe('mockAsync', () => {
 		mockedObservable.flush();
 	}));
 
-	it('should allow unique parameters with successive calls', fakeAsync(() => {
+	it('should allow unique parameters with successive calls', rlFakeAsync(() => {
 		let mockedObservable: IMockedRequest<ITestType> = mock.request((value1: number, value2: number) => {
 			return { value: value1 + value2 };
 		}, true);
@@ -114,7 +114,7 @@ describe('mockAsync', () => {
 		expect(mockedObservable()).to.not.equal(mockedObservable());
 	});
 
-	it('should flush all requests on an unshared mock request', fakeAsync((): void => {
+	it('should flush all requests on an unshared mock request', rlFakeAsync((): void => {
 		let mockedObservable: IMockedRequest<number> = mock.request(result => result);
 		Observable.forkJoin<number[]>([
 			mockedObservable(5),
@@ -134,7 +134,7 @@ describe('mockAsync', () => {
 		sinon.assert.calledWith(mockedObservable, 6);
 	});
 
-	it('should flush all request on an object', fakeAsync((): void => {
+	it('should flush all request on an object', rlFakeAsync((): void => {
 		let service: ITestDataService = {
 			request1: mock.request({ value: 3 }),
 			request2: mock.request({ value: 4 }),
@@ -149,7 +149,7 @@ describe('mockAsync', () => {
 		mock.flushAll(service);
 	}));
 
-	it('should work with Observable.from and Observable.forkJoin', fakeAsync((): void => {
+	it('should work with Observable.from and Observable.forkJoin', rlFakeAsync((): void => {
 		const mockedObservables: IMockedRequest<number>[] = [
 			mock.request(5),
 			mock.request(10),
@@ -165,7 +165,7 @@ describe('mockAsync', () => {
 		mock.flushAll(mockedObservables);
 	}));
 
-	it('should work with toPromise', fakeAsync((): void => {
+	it('should work with toPromise', rlFakeAsync((): void => {
 		let mockedObservable: IMockedRequest<ITestType> = mock.request({ value: 10 });
 		mockedObservable()
 			.toPromise()

--- a/source/services/test/mockAsync.ts
+++ b/source/services/test/mockAsync.ts
@@ -1,6 +1,6 @@
 import { each, isUndefined, isFunction, some, first } from 'lodash';
 import { Observable, Subject } from 'rxjs';
-import { flushMicrotasks, queueRequest } from './fakeAsync';
+import { flushMicrotasks, rlQueueRequest } from './fakeAsync';
 import { IMockedPromise, mockPromise } from './mockPromise';
 
 export { IMockedPromise } from './mockPromise';
@@ -103,7 +103,7 @@ class MockAsyncService implements IMockAsyncService {
 
 			requests.push(newRequest);
 
-			queueRequest(newRequest);
+			rlQueueRequest(newRequest);
 
 			return newRequest.observable;
 		});

--- a/source/services/test/mockPromise.tests.ts
+++ b/source/services/test/mockPromise.tests.ts
@@ -1,5 +1,5 @@
 import { mock, IMockedPromise } from './mockAsync';
-import { fakeAsync } from './fakeAsync';
+import { rlFakeAsync } from './fakeAsync';
 
 interface ITestType {
 	value: number;
@@ -11,7 +11,7 @@ interface ITestDataService {
 }
 
 describe('mockPromise', () => {
-	it('should create a promise that resolves when flushed', fakeAsync(() => {
+	it('should create a promise that resolves when flushed', rlFakeAsync(() => {
 		let mockedPromise: IMockedPromise<ITestType> = mock.promise({ value: 10 });
 		mockedPromise()
 			.then((result: ITestType) => {
@@ -21,7 +21,7 @@ describe('mockPromise', () => {
 		mockedPromise.flush();
 	}));
 
-	it('should create a promise that resolves with dynamic content when flushed', fakeAsync(() => {
+	it('should create a promise that resolves with dynamic content when flushed', rlFakeAsync(() => {
 		let mockedPromise: IMockedPromise<ITestType> = mock.promise((value1: number, value2: number) => {
 			return { value: value1 + value2 };
 		});
@@ -34,7 +34,7 @@ describe('mockPromise', () => {
 		mockedPromise.flush();
 	}));
 
-	it('should create a promise that is rejected', fakeAsync(() => {
+	it('should create a promise that is rejected', rlFakeAsync(() => {
 		let mockedPromise: IMockedPromise<ITestType> = mock.rejectedPromise<ITestType>(new Error('an error'));
 
 		mockedPromise()
@@ -47,7 +47,7 @@ describe('mockPromise', () => {
 		mockedPromise.flush();
 	}));
 
-	it('should create a promise and set it to be rejected', fakeAsync(() => {
+	it('should create a promise and set it to be rejected', rlFakeAsync(() => {
 		let mockedPromise: IMockedPromise<ITestType> = mock.promise<ITestType>({ value: 3 });
 		mockedPromise.reject(new Error('error message'));
 
@@ -61,7 +61,7 @@ describe('mockPromise', () => {
 		mockedPromise.flush();
 	}));
 
-	it('should be able to reuse mocked promises', fakeAsync(() => {
+	it('should be able to reuse mocked promises', rlFakeAsync(() => {
 		let mockedPromise: IMockedPromise<ITestType> = mock.promise<ITestType>({ value: 3 }, true);
 		mockedPromise.reject(new Error('error message'));
 
@@ -80,7 +80,7 @@ describe('mockPromise', () => {
 		mockedPromise.flush();
 	}));
 
-	it('should allow unique parameters with successive calls', fakeAsync(() => {
+	it('should allow unique parameters with successive calls', rlFakeAsync(() => {
 		let mockedPromise: IMockedPromise<ITestType> = mock.promise((value1: number, value2: number) => {
 			return { value: value1 + value2 };
 		}, true);
@@ -113,7 +113,7 @@ describe('mockPromise', () => {
 		expect(mockedPromise()).to.not.equal(mockedPromise());
 	});
 
-	it('should flush all requests on an unshared promise', fakeAsync((): void => {
+	it('should flush all requests on an unshared promise', rlFakeAsync((): void => {
 		let mockedPromise: IMockedPromise<number> = mock.promise(result => result);
 		Promise.all<number>([
 			mockedPromise(5),
@@ -133,7 +133,7 @@ describe('mockPromise', () => {
 		sinon.assert.calledWith(mockedPromise, 6);
 	});
 
-	it('should flush all promises on an object', fakeAsync((): void => {
+	it('should flush all promises on an object', rlFakeAsync((): void => {
 		let service: ITestDataService = {
 			promise1: mock.promise({ value: 3 }),
 			promise2: mock.promise({ value: 4 }),
@@ -148,7 +148,7 @@ describe('mockPromise', () => {
 		mock.flushAll(service);
 	}));
 
-	it('should work with Promise.resolve and Promise.all', fakeAsync((): void => {
+	it('should work with Promise.resolve and Promise.all', rlFakeAsync((): void => {
 		const mockedPromises: IMockedPromise<number>[] = [
 			mock.promise(5),
 			mock.promise(10),

--- a/source/services/test/mockPromise.ts
+++ b/source/services/test/mockPromise.ts
@@ -1,5 +1,5 @@
 import * as _ from 'lodash';
-import { flushMicrotasks, queueRequest } from './fakeAsync';
+import { flushMicrotasks, rlQueueRequest } from './fakeAsync';
 
 export interface IMockPromiseService {
 	promise<TData>(result?: TData | { (...args: any[]): TData }, share?: boolean): IMockedPromise<TData>;
@@ -89,7 +89,7 @@ class MockPromiseService implements IMockPromiseService {
 
 			requests.push(newRequest);
 
-			queueRequest(newRequest);
+			rlQueueRequest(newRequest);
 
 			return newRequest.promise;
 		});

--- a/source/services/timeout/timeout.service.tests.ts
+++ b/source/services/timeout/timeout.service.tests.ts
@@ -1,6 +1,6 @@
 import { TimeoutService, ITimeout } from './timeout.service';
 
-import { fakeAsync, tick, flushMicrotasks } from '../test/fakeAsync';
+import { rlFakeAsync, rlTick, flushMicrotasks } from '../test/fakeAsync';
 
 describe('TimeoutService', (): void => {
 	let timeoutService: TimeoutService;
@@ -9,20 +9,20 @@ describe('TimeoutService', (): void => {
 		timeoutService = new TimeoutService();
 	});
 
-	it('should resolve the promise and call the callback when the timeout finishes', fakeAsync((): void => {
+	it('should resolve the promise and call the callback when the timeout finishes', rlFakeAsync((): void => {
 		const promiseSpy: Sinon.SinonSpy = sinon.spy();
 		const callback: Sinon.SinonSpy = sinon.spy();
 
 		timeoutService.setTimeout(callback, 2000).then(promiseSpy);
 
-		tick(2000);
+		rlTick(2000);
 		flushMicrotasks();
 
 		sinon.assert.calledOnce(promiseSpy);
 		sinon.assert.calledOnce(callback);
 	}));
 
-	it('should reject the promise without calling the callback if the timeout is canceled', fakeAsync((): void => {
+	it('should reject the promise without calling the callback if the timeout is canceled', rlFakeAsync((): void => {
 		const rejectSpy: Sinon.SinonSpy = sinon.spy();
 		const callback: Sinon.SinonSpy = sinon.spy();
 
@@ -31,14 +31,14 @@ describe('TimeoutService', (): void => {
 												.catch(rejectSpy);
 
 		timeout.cancel();
-		tick(2000);
+		rlTick(2000);
 		flushMicrotasks();
 
 		sinon.assert.calledOnce(rejectSpy);
 		sinon.assert.notCalled(callback);
 	}));
 
-	it('should allow for specifying just a duration for chaining as a promise', fakeAsync((): void => {
+	it('should allow for specifying just a duration for chaining as a promise', rlFakeAsync((): void => {
 		const promiseSpy: Sinon.SinonSpy = sinon.spy();
 
 		timeoutService.setTimeout(2000).then(promiseSpy);
@@ -46,7 +46,7 @@ describe('TimeoutService', (): void => {
 		flushMicrotasks();
 		sinon.assert.notCalled(promiseSpy);
 
-		tick(2000);
+		rlTick(2000);
 		flushMicrotasks();
 
 		sinon.assert.calledOnce(promiseSpy);


### PR DESCRIPTION
After some investigation, I've discovered that the reason scheduling rxjs tests is currently not possible is that the scheduler always depends on the current browser time. If we instead tie this to the elapsed time of the fake async zone based on 'tick', we'll gain the ability to also schedule rxjs tasks in tests. Requires wrapping angular 'tick' so we can track the elapsed time.

This only impacts unit tests, so it shouldn't need to be incorporated into the WIP pipeline.

https://renovo.myjetbrains.com/youtrack/issue/RLv21-54
