### PR TITLE
Allow for mocking the delete action on data contracts

### DIFF
--- a/source/services/dataContracts/contractLibrary/contractLibrary.ts
+++ b/source/services/dataContracts/contractLibrary/contractLibrary.ts
@@ -135,6 +135,7 @@ export class ContractLibrary implements IContractLibrary {
 		dataService.mockGetDetail = (data: any): IMockedRequest<any> => { return this.baseMockGet(dataService, 'get', data); };
 		dataService.mockUpdate = (dataTransform?: IDataTransform): IMockedRequest<any> => { return this.baseMockSave(dataService, 'update', dataTransform); };
 		dataService.mockCreate = (dataTransform?: IDataTransform): IMockedRequest<any> => { return this.baseMockSave(dataService, 'create', dataTransform); };
+		dataService.mockDelete = (): IMockedRequest<any> => { return this.baseMockSave(dataService, 'delete', () => null); };
 		dataService = this.updateResource(dataService, resource);
 		return dataService;
 	}
@@ -149,6 +150,7 @@ export class ContractLibrary implements IContractLibrary {
 		dataService.mockChild = (mockCallback: { (children: any): void }): void => { return this.mockChild(dataService, mockCallback); };
 		dataService.mockUpdate = (dataTransform?: IDataTransform): IMockedRequest<any> => { return this.baseMockSave(dataService, 'update', dataTransform); };
 		dataService.mockCreate = (dataTransform?: IDataTransform): IMockedRequest<any> => { return this.baseMockSave(dataService, 'create', dataTransform); };
+		dataService.mockDelete = (): IMockedRequest<any> => { return this.baseMockSave(dataService, 'delete', () => null); };
 		dataService = this.updateResource(dataService, resource);
 		return dataService;
 	}

--- a/source/services/dataContracts/contractLibrary/dataServiceMocks.ts
+++ b/source/services/dataContracts/contractLibrary/dataServiceMocks.ts
@@ -12,6 +12,7 @@ export interface IDataServiceMock<TDataType extends IBaseDomainObject, TSearchPa
 	mockGetDetail(data: any): IMockedRequest<any>;
 	mockUpdate(dataTransform?: IDataTransform): IMockedRequest<any>;
 	mockCreate(dataTransform?: IDataTransform): IMockedRequest<any>;
+	mockDelete(): IMockedRequest<any>;
 }
 
 export interface IParentDataServiceMock<TDataType extends IBaseDomainObject, TSearchParams, TResourceDictionaryType> extends IParentDataService<TDataType, TSearchParams, TResourceDictionaryType> {
@@ -20,6 +21,7 @@ export interface IParentDataServiceMock<TDataType extends IBaseDomainObject, TSe
 	mockChild(mockCallback: { (children: any): void }): void;
 	mockUpdate(dataTransform?: IDataTransform): IMockedRequest<any>;
 	mockCreate(dataTransform?: IDataTransform): IMockedRequest<any>;
+	mockDelete(): IMockedRequest<any>;
 }
 
 export interface ISingletonDataServiceMock<TDataType> extends ISingletonDataService<TDataType> {


### PR DESCRIPTION
I was going to add some more unit tests in service events, but these included a case where `delete` needs to be mocked. I realized functionality for mocking delete had never been implemented yet. 

Only impacts the tests. Shouldn't break anything even there since there are only additions.
