### PR TITLE
Allow for specifying a format when checking for a date is in a range

### DIFF
--- a/source/services/date/date.service.tests.ts
+++ b/source/services/date/date.service.tests.ts
@@ -333,6 +333,12 @@ describe('dateUtility', () => {
 			expect(dateUtility.dateInRange('2016-01-01T12:00:00-07:00', '2016-01-01T12:00:00-07:00', null)).to.be.null;
 			expect(dateUtility.dateInRange(null, null, null)).to.be.null;
 		});
+
+		it('should allow for specifying a format', () => {
+			expect(dateUtility.dateInRange(moment('2016-08-29T12:00:00'), '1/1/2015', '1/1/2016', defaultFormats.dateFormat)).to.be.false;
+			expect(dateUtility.dateInRange(moment('2016-08-29T12:00:00'), '1/1/2016', '1/1/2017', defaultFormats.dateFormat)).to.be.true;
+			expect(dateUtility.dateInRange(moment('2016-08-29T12:00:00'), '1/1/2017', '1/1/2018', defaultFormats.dateFormat)).to.be.false;
+		});
 	});
 
 	describe('sameDate', (): void=> {

--- a/source/services/date/date.service.ts
+++ b/source/services/date/date.service.ts
@@ -27,7 +27,7 @@ export interface IDateUtility {
 	subtractDateInMilliseconds(start: string | Date | moment.Moment, end: string | Date | moment.Moment, dateFormat?: string): number;
 	subtractDatesMoment(start: string | Date | moment.Moment, end: string | Date | moment.Moment, dateFormat?: string): moment.Duration;
 	compareDates(date1: string | Date | moment.Moment, date2: string | Date | moment.Moment, dateFormat?: string): CompareResult;
-	dateInRange(date: string | Date | moment.Moment, rangeStart: string | Date | moment.Moment, rangeEnd: string | Date | moment.Moment): boolean;
+	dateInRange(date: string | Date | moment.Moment, rangeStart: string | Date | moment.Moment, rangeEnd: string | Date | moment.Moment, dateFormat?: string): boolean;
 	getDateFromISOString(date: string): moment.Moment;
 	isDate(date: string | Date | moment.Moment, dateFormat?: string): boolean;
 	getNow(): moment.Moment;
@@ -89,13 +89,13 @@ export class DateUtility {
 		return getCompareResult(difference);
 	}
 
-	dateInRange(date: string | Date | moment.Moment, rangeStart: string | Date | moment.Moment, rangeEnd: string | Date | moment.Moment): boolean {
+	dateInRange(date: string | Date | moment.Moment, rangeStart: string | Date | moment.Moment, rangeEnd: string | Date | moment.Moment, dateFormat?: string): boolean {
 		if (date == null || rangeStart == null || rangeEnd == null) {
 			return null;
 		}
 
-		if (this.compareDates(date, rangeStart) === CompareResult.less
-			|| this.compareDates(date, rangeEnd) === CompareResult.greater) {
+		if (this.compareDates(date, rangeStart, dateFormat) === CompareResult.less
+			|| this.compareDates(date, rangeEnd, dateFormat) === CompareResult.greater) {
 			return false;
 		} else {
 			return true;


### PR DESCRIPTION
In our app, we're sometimes getting dates in mm/dd/yyyy format. Moment doesn't handle this by default anymore, so we need to specify a format for these. Added a unit test comparing dates in this format with a moment to prove that this works.
