### PR TITLE
Add ability to set a millisecond offset on date utility

### DIFF
--- a/source/services/date/date.service.tests.ts
+++ b/source/services/date/date.service.tests.ts
@@ -388,4 +388,33 @@ describe('dateUtility', () => {
 			expect(dateUtility.sameDateTime(null, null)).to.be.null;
 		});
 	});
+
+	describe('setOffset', (): void => {
+		let offset = 500;
+		let originalMomentNow: any;
+
+		beforeEach(() => {
+			originalMomentNow = moment.now;
+		});
+
+		afterEach(() => {
+			moment.now = originalMomentNow;
+		});
+
+		it('should offset current moment time', (): void => {
+			let nowBeforeOffset = moment.now();
+			dateUtility.setOffset(offset);
+			let nowAfterOffset = moment.now();
+
+			expect(nowAfterOffset - nowBeforeOffset).to.equal(offset);
+		});
+
+		it('should offset current date service time', (): void => {
+			let nowBeforeOffset = dateUtility.getNow();
+			dateUtility.setOffset(offset);
+			let nowAfterOffset = dateUtility.getNow();
+
+			expect(nowAfterOffset.valueOf() - nowBeforeOffset.valueOf()).to.equal(offset);
+		});
+	});
 });

--- a/source/services/date/date.service.ts
+++ b/source/services/date/date.service.ts
@@ -34,10 +34,12 @@ export interface IDateUtility {
 	formatDate(date: string | Date | moment.Moment, dateFormat?: string): string;
 	sameDate(date1: string | Date | moment.Moment, date2: string | Date | moment.Moment, date1Format?: string, date2Format?: string): boolean;
 	sameDateTime(date1: string | Date | moment.Moment, date2: string | Date | moment.Moment, date1Format?: string, date2Format?: string): boolean;
+	setOffset(millis: number);
 }
 
 export class DateUtility {
 	private baseFormat: string = defaultFormats.isoFormat;
+	private offsetFromServer: number;
 
 	getFullString(month: number): string {
 		return moment().month(month).format('MMMM');
@@ -127,11 +129,14 @@ export class DateUtility {
 	}
 
 	getNow(): moment.Moment {
+		let now = moment();
 		if (timezoneService.currentTimezone != null)
 		{
-			return moment().tz(timezoneService.currentTimezone.momentName);
+			now = now.tz(timezoneService.currentTimezone.momentName);
 		}
-		return moment();
+
+		now.add(this.offsetFromServer, 'milliseconds');
+		return now;
 	}
 
 	formatDate(date: string | Date | moment.Moment, dateFormat?: string): string {
@@ -158,6 +163,10 @@ export class DateUtility {
 
 	sameDateTime(date1: string | Date | moment.Moment, date2: string | Date | moment.Moment, date1Format?: string, date2Format?: string): boolean {
 		return this.sameDate(date1, date2, date1Format, date2Format, 'milliseconds');
+	}
+
+	setOffset(millis: number) {
+		this.offsetFromServer = millis;
 	}
 
 	private parseDate(date: string | Date | moment.Moment, dateFormat?: string): moment.Moment {

--- a/source/services/date/date.service.ts
+++ b/source/services/date/date.service.ts
@@ -39,7 +39,6 @@ export interface IDateUtility {
 
 export class DateUtility {
 	private baseFormat: string = defaultFormats.isoFormat;
-	private offsetFromServer: number;
 
 	getFullString(month: number): string {
 		return moment().month(month).format('MMMM');
@@ -129,14 +128,7 @@ export class DateUtility {
 	}
 
 	getNow(): moment.Moment {
-		let now = moment();
-		if (timezoneService.currentTimezone != null)
-		{
-			now = now.tz(timezoneService.currentTimezone.momentName);
-		}
-
-		now.add(this.offsetFromServer, 'milliseconds');
-		return now;
+		return this.setTimezone(moment());
 	}
 
 	formatDate(date: string | Date | moment.Moment, dateFormat?: string): string {
@@ -166,7 +158,11 @@ export class DateUtility {
 	}
 
 	setOffset(millis: number) {
-		this.offsetFromServer = millis;
+		moment.now = () => {
+			let now = moment(new Date());
+			now = this.setTimezone(now);
+			return now.valueOf() + millis;
+		}
 	}
 
 	private parseDate(date: string | Date | moment.Moment, dateFormat?: string): moment.Moment {
@@ -179,6 +175,15 @@ export class DateUtility {
 
 	private getFormat(customFormat: string): string {
 		return customFormat != null ? customFormat : this.baseFormat;
+	}
+
+	private setTimezone(date: moment.Moment) {
+		if (timezoneService.currentTimezone != null)
+		{
+			date = date.tz(timezoneService.currentTimezone.momentName);
+		}
+
+		return date;
 	}
 }
 


### PR DESCRIPTION
For example, if an offset of 500ms is provided the returned value of `dateService.getNow()` and `moment()` will have 500ms added to them. This is useful for scenarios such as offsetting the client clock to synchronize with the server clock. 

By default, there is no offset so behavior remains the same unless `setOffset(...)` is called.

Relates to https://renovo.myjetbrains.com/youtrack/issue/MUSIC-826
