### PR TITLE
TypeScript 2.0 builld errors.

### DIFF
--- a/source/services/date/date.service.tests.ts
+++ b/source/services/date/date.service.tests.ts
@@ -398,7 +398,7 @@ describe('dateUtility', () => {
 		});
 
 		afterEach(() => {
-			moment.now = originalMomentNow;
+			(<any>moment).now = originalMomentNow;
 		});
 
 		it('should offset current moment time', (): void => {

--- a/source/services/date/date.service.ts
+++ b/source/services/date/date.service.ts
@@ -160,7 +160,7 @@ export class DateUtility {
 	}
 
 	setOffset(millis: number) {
-		moment.now = () => {
+		(<any>moment).now = () => {
 			let now = moment(new Date());
 			now = this.setTimezone(now);
 			return now.valueOf() + millis;


### PR DESCRIPTION
TS 2.0 considers imports to be consts which is why to set these we had to but moment in (<any>moment).  if not the complier was unhappy.
