### PR TITLE
Observable validators

### DIFF
--- a/source/services/index.ts
+++ b/source/services/index.ts
@@ -79,6 +79,7 @@ export const UTILITY_PROVIDERS: (Provider | Provider[] | any)[] = [
 	timezone.TimezoneService,
 	transform.TransformService,
 
+	validation.ObservableValidator,
 	validation.ValidationService,
 	emailValidation.EmailValidationService,
 	logger.Logger,

--- a/source/services/validation/observableValidator.tests.ts
+++ b/source/services/validation/observableValidator.tests.ts
@@ -44,7 +44,7 @@ describe('ObservableValidator', () => {
 
 			validator.validate().subscribe(valid => result = valid);
 
-			expect(result).to.not.exist;
+			expect(result).to.be.null;
 		});
 	});
 

--- a/source/services/validation/observableValidator.tests.ts
+++ b/source/services/validation/observableValidator.tests.ts
@@ -1,0 +1,86 @@
+import { Subject, Observable } from 'rxjs';
+
+import { ObservableValidator } from './observableValidator';
+
+describe('ObservableValidator', () => {
+	let validator: ObservableValidator;
+
+	beforeEach(() => {
+		validator = new ObservableValidator();
+	});
+
+	describe('validate', () => {
+		it('should return the error on the first validator', () => {
+			const errorString = 'error123';
+			const firstHandler = {
+				validate: () => Observable.of(errorString),
+			};
+			const secondHandler = {
+				validate: () => Observable.of('other'),
+			};
+			validator.registerValidationHandler(firstHandler);
+			validator.registerValidationHandler(secondHandler);
+			let result;
+
+			validator.validate().subscribe(valid => result = valid);
+
+			expect(result).to.equal(errorString);
+		});
+
+		it('should return null if no errors are found', () => {
+			const firstHandler = {
+				validate: () => Observable.of(null),
+			};
+			validator.registerValidationHandler(firstHandler);
+			let result;
+
+			validator.validate().subscribe(valid => result = valid);
+
+			expect(result).to.not.exist;
+		});
+
+		it('should return null if no validators are registered', () => {
+			let result;
+
+			validator.validate().subscribe(valid => result = valid);
+
+			expect(result).to.not.exist;
+		});
+	});
+
+	describe('isActive', () => {
+		it('should ignore a validator with isActive set as false', () => {
+			const firstHandler = {
+				validate: () => Observable.of('error'),
+				isActive: false,
+			};
+			validator.registerValidationHandler(firstHandler);
+			let result;
+
+			validator.validate().subscribe(valid => result = valid);
+
+			expect(result).to.not.exist;
+		});
+
+		it('should get the validation error when the validator becomes active', () => {
+			const error = 'error';
+			const firstHandler = {
+				validate: () => Observable.of(error),
+				isActive: () => firstHandler.activeStream,
+				activeStream: new Subject<boolean>(),
+			};
+			validator.registerValidationHandler(firstHandler);
+			let result;
+
+			validator.validate().subscribe(valid => result = valid);
+
+			firstHandler.activeStream.next(false);
+
+			expect(result).to.not.exist;
+
+			firstHandler.activeStream.next(true);
+
+			expect(result).to.equal(error);
+		});
+	});
+});

--- a/source/services/validation/observableValidator.ts
+++ b/source/services/validation/observableValidator.ts
@@ -1,0 +1,40 @@
+import { Observable } from 'rxjs';
+import { map, find, isFunction } from 'lodash';
+
+import { IUnregisterFunction, IObservableValidator, IObservableValidationHandler } from './validationTypes';
+
+export class ObservableValidator implements IObservableValidator {
+	private validationHandlers: { [index: string]: IObservableValidationHandler } = {};
+	private nextKey: number = 0;
+
+	validate(value$?: Observable<any>): Observable<string> {
+		return Observable.combineLatest(map(this.validationHandlers, handler => this.getValidationResult(handler, value$)))
+						 .map(results => find(results, x => x != null));
+	}
+
+	registerValidationHandler(handler: IObservableValidationHandler): IUnregisterFunction {
+		var currentKey: number = this.nextKey;
+		this.nextKey++;
+		this.validationHandlers[currentKey] = handler;
+
+		return (): void => {
+			this.unregister(currentKey);
+		};
+	}
+
+	private unregister(key: number): void {
+		delete this.validationHandlers[key];
+	}
+
+	private isActive(handler: IObservableValidationHandler): Observable<boolean> {
+		return (isFunction(handler.isActive) && (<{(): Observable<boolean>}>handler.isActive)())
+			|| Observable.of(handler.isActive == null)
+			|| Observable.of(handler.isActive === true);
+	}
+
+	private getValidationResult(handler: IObservableValidationHandler, value$: Observable<any>): Observable<string> {
+		return this.isActive(handler)
+				   .switchMap(active => active ? handler.validate(value$) : Observable.of(null))
+				   .filter(validationError => validationError != null);
+	}
+}

--- a/source/services/validation/observableValidator.ts
+++ b/source/services/validation/observableValidator.ts
@@ -1,5 +1,5 @@
 import { Observable } from 'rxjs';
-import { map, find, isFunction } from 'lodash';
+import { map, find, isFunction, values } from 'lodash';
 
 import { IUnregisterFunction, IObservableValidator, IObservableValidationHandler } from './validationTypes';
 
@@ -8,6 +8,10 @@ export class ObservableValidator implements IObservableValidator {
 	private nextKey: number = 0;
 
 	validate(value$?: Observable<any>): Observable<string> {
+		if (!values(this.validationHandlers).length) {
+			return Observable.of(null);
+		}
+
 		return Observable.combineLatest(map(this.validationHandlers, handler => this.getValidationResult(handler, value$)))
 						 .map(results => find(results, x => x != null));
 	}

--- a/source/services/validation/observableValidator.ts
+++ b/source/services/validation/observableValidator.ts
@@ -34,7 +34,6 @@ export class ObservableValidator implements IObservableValidator {
 
 	private getValidationResult(handler: IObservableValidationHandler, value$: Observable<any>): Observable<string> {
 		return this.isActive(handler)
-				   .switchMap(active => active ? handler.validate(value$) : Observable.of(null))
-				   .filter(validationError => validationError != null);
+				   .switchMap(active => active ? handler.validate(value$) : Observable.of(null));
 	}
 }

--- a/source/services/validation/validation.service.ts
+++ b/source/services/validation/validation.service.ts
@@ -7,6 +7,7 @@ import { INotificationService, NotificationService } from '../notification/notif
 import { ISimpleValidator, IErrorHandler, ICompositeValidator } from './validationTypes';
 import { Validator } from './validator';
 import { CompositeValidator } from './compositeValidator';
+import { ObservableValidator } from './observableValidator';
 
 export * from './observableValidator';
 export * from './validationTypes';
@@ -48,6 +49,11 @@ export interface IValidationService {
 	 * @param showError A custom handler for validation errors
 	 */
 	buildCompositeCustomValidator(showError: IErrorHandler): ICompositeValidator;
+
+	/**
+	 * Build a validator that validates against a stream
+	 */
+	buildObservableValidator(): ObservableValidator;
 }
 
 @Injectable()
@@ -88,5 +94,9 @@ export class ValidationService implements IValidationService {
 
 	buildCompositeCustomValidator(showError: IErrorHandler): ICompositeValidator {
 		return new CompositeValidator(showError);
+	}
+
+	buildObservableValidator(): ObservableValidator {
+		return new ObservableValidator();
 	}
 }

--- a/source/services/validation/validation.service.ts
+++ b/source/services/validation/validation.service.ts
@@ -8,6 +8,7 @@ import { ISimpleValidator, IErrorHandler, ICompositeValidator } from './validati
 import { Validator } from './validator';
 import { CompositeValidator } from './compositeValidator';
 
+export * from './observableValidator';
 export * from './validationTypes';
 
 export interface IValidationService {

--- a/source/services/validation/validationTypes.ts
+++ b/source/services/validation/validationTypes.ts
@@ -1,6 +1,12 @@
+import { Observable } from 'rxjs';
+
 export interface IValidator {
 	validate(value?: any): boolean;
 	getErrorCount(): number;
+}
+
+export interface IObservableValidator {
+	validate(value$?: Observable<any>): Observable<string>;
 }
 
 export interface ISimpleValidator extends IValidator {
@@ -17,6 +23,12 @@ export interface IValidationHandler {
 	validate(value?: any): boolean;
 	errorMessage: string | { (): string };
 	name?: string;
+}
+
+export interface IObservableValidationHandler {
+	name?: string;
+	isActive?: {(): Observable<boolean>} | boolean;
+	validate(value$?: Observable<any>): Observable<string>;
 }
 
 export interface IErrorHandler {


### PR DESCRIPTION
Created a service for representing a validator as a stream. This will make change detection easier for validation. For input validation, we have cases where the validation depends on an external field. This has issues when the external data updates and we have no way to get notified. By representing validation as a stream, consumers can merge external data streams in to make a validation check, and we'll get notified of changes automatically.
