### PR TITLE
Angular 2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,13 +50,13 @@
     "typescript": "~2.0.3"
   },
   "dependencies": {
-    "@angular/common": "~2.3.0",
-    "@angular/compiler": "~2.3.0",
-    "@angular/core": "~2.3.0",
-    "@angular/http": "~2.3.0",
-    "@angular/platform-browser": "~2.3.0",
-    "@angular/platform-browser-dynamic": "~2.3.0",
-    "@angular/upgrade": "~2.3.0",
+    "@angular/common": "~2.4.0",
+    "@angular/compiler": "~2.4.0",
+    "@angular/core": "~2.4.0",
+    "@angular/http": "~2.4.0",
+    "@angular/platform-browser": "~2.4.0",
+    "@angular/platform-browser-dynamic": "~2.4.0",
+    "@angular/upgrade": "~2.4.0",
     "@types/angular": "^1.5.16",
     "@types/angular-mocks": "^1.5.5",
     "@types/chai": "^3.4.33",
@@ -73,9 +73,9 @@
     "moment": "~2.14.1",
     "moment-timezone": "~0.5.3",
     "reflect-metadata": "0.1.2",
-    "rl-async-testing": "~1.5.0",
-    "rl-http": "~1.4.0",
-    "rxjs": "5.0.0-beta.12",
+    "rl-async-testing": "~1.6.0",
+    "rl-http": "~1.5.0",
+    "rxjs": "~5.0.0",
     "zone.js": "~0.6.25"
   },
   "license": "MIT"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-angular-utilities",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "Typescript utility classes published as angular services",
   "author": "Renovo Development Team",
   "main": "source/main.js",


### PR DESCRIPTION
Because of issues with version mismatches, I decided to jump straight to angular 2.4. No breaking changes except dropping rxjs `.cache()`, which is easily fixable.