### PR TITLE
Need systemjs as an explicit dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "npm-run-all": "~3.1.0",
     "run-sequence": "^1.1.5",
     "sinon": "~1.17.3",
+    "systemjs": "^0.19.36",
     "systemjs-builder": "^0.15.16",
     "typescript": "~2.1.5"
   },


### PR DESCRIPTION
We'll just add it as a dev dependency since we don't actually care that our consumers have it when they run the app. (They just need to use our javascript files)

This is the version referenced by app core. In components, we use the '^' so I'm going to be equally flexible here.