### PR TITLE
Increase timeout for unit test runners

### DIFF
--- a/config/karma.shared.conf.js
+++ b/config/karma.shared.conf.js
@@ -68,5 +68,7 @@ module.exports = function (karma) {
 
 			{ pattern: 'source/**', included: false, watched: true }
 		],
+
+		browserNoActivityTimeout: 100000,
 	};
 };


### PR DESCRIPTION
Not every unit test runner can start reliably in 10 seconds. This increases the timeout so that unit tests are more likely to pass.